### PR TITLE
Enhance OGC Tiles API with dynamic metadata and comprehensive documentation

### DIFF
--- a/src/xpublish_tiles/xpublish/tiles/models.py
+++ b/src/xpublish_tiles/xpublish/tiles/models.py
@@ -2,7 +2,7 @@
 
 import re
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Annotated, Any, Optional, Union
 
 import pyproj
 from pydantic import BaseModel, Field, field_validator
@@ -11,19 +11,59 @@ from pydantic import BaseModel, Field, field_validator
 class MD_ReferenceSystem(BaseModel):
     """ISO 19115 MD_ReferenceSystem data structure"""
 
-    code: Optional[str] = None
-    codeSpace: Optional[str] = None
-    version: Optional[str] = None
+    code: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Alphanumeric value identifying an instance in the namespace",
+            }
+        ),
+    ] = None
+    codeSpace: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Name or identifier of the person or organization responsible for namespace",
+            }
+        ),
+    ] = None
+    version: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Identifier of the version of the associated codeSpace or code",
+            }
+        ),
+    ] = None
 
 
 class CRSType(BaseModel):
     """CRS definition supporting URI, WKT2, or ISO 19115 MD_ReferenceSystem"""
 
-    uri: Optional[str] = Field(None, description="A reference to a CRS, typically EPSG")
-    wkt: Optional[Any] = Field(None, description="WKT2 CRS definition")
-    referenceSystem: Optional[MD_ReferenceSystem] = Field(
-        None, description="ISO 19115 reference system"
-    )
+    uri: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "A reference to a CRS, typically EPSG",
+            }
+        ),
+    ] = None
+    wkt: Annotated[
+        Optional[Any],
+        Field(
+            json_schema_extra={
+                "description": "WKT2 CRS definition",
+            }
+        ),
+    ] = None
+    referenceSystem: Annotated[
+        Optional[MD_ReferenceSystem],
+        Field(
+            json_schema_extra={
+                "description": "ISO 19115 reference system",
+            }
+        ),
+    ] = None
 
     @field_validator("uri")
     @classmethod
@@ -79,67 +119,284 @@ class CRSType(BaseModel):
 class Link(BaseModel):
     """A link to another resource"""
 
-    href: str
-    rel: str
-    type: Optional[str] = None
-    title: Optional[str] = None
-    templated: Optional[bool] = None
-    varBase: Optional[str] = None
-    hreflang: Optional[str] = None
-    length: Optional[int] = None
+    href: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "The URI of the linked resource",
+            }
+        ),
+    ]
+    rel: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "The relationship type of the linked resource",
+            }
+        ),
+    ]
+    type: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "The media type of the linked resource",
+            }
+        ),
+    ] = None
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "A human-readable title for the link",
+            }
+        ),
+    ] = None
+    templated: Annotated[
+        Optional[bool],
+        Field(
+            json_schema_extra={
+                "description": "Whether the href is a URI template",
+            }
+        ),
+    ] = None
+    varBase: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Base URI for template variable resolution",
+            }
+        ),
+    ] = None
+    hreflang: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Language of the linked resource",
+            }
+        ),
+    ] = None
+    length: Annotated[
+        Optional[int],
+        Field(
+            json_schema_extra={
+                "description": "Length of the linked resource in bytes",
+            }
+        ),
+    ] = None
 
 
 class ConformanceDeclaration(BaseModel):
     """OGC API conformance declaration"""
 
-    conformsTo: list[str]
+    conformsTo: Annotated[
+        list[str],
+        Field(
+            json_schema_extra={
+                "description": "List of conformance class URIs that this API conforms to",
+            }
+        ),
+    ]
 
 
 class BoundingBox(BaseModel):
     """Bounding box definition"""
 
-    lowerLeft: list[float]  # [minX, minY]
-    upperRight: list[float]  # [maxX, maxY]
-    crs: Optional[Union[str, CRSType]] = None
-    orderedAxes: Optional[list[str]] = None
+    lowerLeft: Annotated[
+        list[float],
+        Field(
+            json_schema_extra={
+                "description": "Lower left corner coordinates [minX, minY]",
+            }
+        ),
+    ]
+    upperRight: Annotated[
+        list[float],
+        Field(
+            json_schema_extra={
+                "description": "Upper right corner coordinates [maxX, maxY]",
+            }
+        ),
+    ]
+    crs: Annotated[
+        Optional[Union[str, CRSType]],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system of the bounding box",
+            }
+        ),
+    ] = None
+    orderedAxes: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "Ordered list of axis names for the CRS",
+            }
+        ),
+    ] = None
 
 
 class TileMatrix(BaseModel):
     """Definition of a tile matrix within a tile matrix set"""
 
-    id: str
-    scaleDenominator: float
-    topLeftCorner: list[float]
-    tileWidth: int
-    tileHeight: int
-    matrixWidth: int
-    matrixHeight: int
+    id: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier for this tile matrix",
+            }
+        ),
+    ]
+    scaleDenominator: Annotated[
+        float,
+        Field(
+            json_schema_extra={
+                "description": "Scale denominator for this tile matrix level",
+            }
+        ),
+    ]
+    topLeftCorner: Annotated[
+        list[float],
+        Field(
+            json_schema_extra={
+                "description": "Top-left corner coordinates of the tile matrix",
+            }
+        ),
+    ]
+    tileWidth: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Width of each tile in pixels",
+            }
+        ),
+    ]
+    tileHeight: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Height of each tile in pixels",
+            }
+        ),
+    ]
+    matrixWidth: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Number of tiles in the horizontal direction",
+            }
+        ),
+    ]
+    matrixHeight: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Number of tiles in the vertical direction",
+            }
+        ),
+    ]
 
 
 class TileMatrixSet(BaseModel):
     """Complete tile matrix set definition"""
 
-    id: str
-    title: Optional[str] = None
-    uri: Optional[str] = None
-    crs: Union[str, CRSType]
-    tileMatrices: list[TileMatrix]
+    id: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier for this tile matrix set",
+            }
+        ),
+    ]
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this tile matrix set",
+            }
+        ),
+    ] = None
+    uri: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "URI identifier for this tile matrix set",
+            }
+        ),
+    ] = None
+    crs: Annotated[
+        Union[str, CRSType],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system used by this tile matrix set",
+            }
+        ),
+    ]
+    tileMatrices: Annotated[
+        list[TileMatrix],
+        Field(
+            json_schema_extra={
+                "description": "List of tile matrices in this set",
+            }
+        ),
+    ]
 
 
 class TileMatrixSetSummary(BaseModel):
     """Summary of a tile matrix set for listings"""
 
-    id: str
-    title: Optional[str] = None
-    uri: Optional[str] = None
-    crs: Union[str, CRSType]
-    links: list[Link]
+    id: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier for this tile matrix set",
+            }
+        ),
+    ]
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this tile matrix set",
+            }
+        ),
+    ] = None
+    uri: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "URI identifier for this tile matrix set",
+            }
+        ),
+    ] = None
+    crs: Annotated[
+        Union[str, CRSType],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system used by this tile matrix set",
+            }
+        ),
+    ]
+    links: Annotated[
+        list[Link],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this tile matrix set",
+            }
+        ),
+    ]
 
 
 class TileMatrixSets(BaseModel):
     """Collection of tile matrix sets"""
 
-    tileMatrixSets: list[TileMatrixSetSummary]
+    tileMatrixSets: Annotated[
+        list[TileMatrixSetSummary],
+        Field(
+            json_schema_extra={
+                "description": "List of available tile matrix sets",
+            }
+        ),
+    ]
 
 
 class DataType(str, Enum):
@@ -153,54 +410,285 @@ class DataType(str, Enum):
 class TileSetMetadata(BaseModel):
     """Metadata for a tileset applied to a specific dataset"""
 
-    title: Optional[str] = None
-    tileMatrixSetURI: str
-    crs: Union[str, CRSType]
-    dataType: Union[DataType, str]  # "map", "vector", "coverage"
-    links: list[Link]
-    boundingBox: Optional[BoundingBox] = None
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this tileset",
+            }
+        ),
+    ] = None
+    tileMatrixSetURI: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "URI of the tile matrix set used by this tileset",
+            }
+        ),
+    ]
+    crs: Annotated[
+        Union[str, CRSType],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system used by this tileset",
+            }
+        ),
+    ]
+    dataType: Annotated[
+        Union[DataType, str],
+        Field(
+            json_schema_extra={
+                "description": "Type of data contained in the tiles (map, vector, coverage)",
+            }
+        ),
+    ]
+    links: Annotated[
+        list[Link],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this tileset",
+            }
+        ),
+    ]
+    boundingBox: Annotated[
+        Optional[BoundingBox],
+        Field(
+            json_schema_extra={
+                "description": "Bounding box of the tileset data",
+            }
+        ),
+    ] = None
 
 
 class TileMatrixSetLimit(BaseModel):
     """Limits for a specific tile matrix"""
 
-    tileMatrix: str
-    minTileRow: int
-    maxTileRow: int
-    minTileCol: int
-    maxTileCol: int
+    tileMatrix: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier of the tile matrix these limits apply to",
+            }
+        ),
+    ]
+    minTileRow: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Minimum tile row index",
+            }
+        ),
+    ]
+    maxTileRow: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Maximum tile row index",
+            }
+        ),
+    ]
+    minTileCol: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Minimum tile column index",
+            }
+        ),
+    ]
+    maxTileCol: Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "description": "Maximum tile column index",
+            }
+        ),
+    ]
 
 
 class Style(BaseModel):
     """Style definition"""
 
-    id: str
-    title: Optional[str] = None
-    description: Optional[str] = None
-    keywords: Optional[list[str]] = None
-    links: Optional[list[Link]] = None
+    id: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier for this style",
+            }
+        ),
+    ]
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this style",
+            }
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Brief narrative description of this style",
+            }
+        ),
+    ] = None
+    keywords: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "Keywords associated with this style",
+            }
+        ),
+    ] = None
+    links: Annotated[
+        Optional[list[Link]],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this style",
+            }
+        ),
+    ] = None
 
 
 class PropertySchema(BaseModel):
     """Schema definition for a property"""
 
-    title: Optional[str] = None
-    description: Optional[str] = None
-    type: Optional[str] = None
-    enum: Optional[list[str]] = None
-    format: Optional[str] = None
-    contentMediaType: Optional[str] = None
-    maximum: Optional[float] = None
-    exclusiveMaximum: Optional[float] = None
-    minimum: Optional[float] = None
-    exclusiveMinimum: Optional[float] = None
-    pattern: Optional[str] = None
-    maxItems: Optional[int] = None
-    minItems: Optional[int] = None
-    observedProperty: Optional[str] = None
-    observedPropertyURI: Optional[str] = None
-    uom: Optional[str] = None
-    uomURI: Optional[str] = None
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this property",
+            }
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Description of this property",
+            }
+        ),
+    ] = None
+    type: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Data type of this property",
+            }
+        ),
+    ] = None
+    enum: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "List of valid enumerated values",
+            }
+        ),
+    ] = None
+    format: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Format specification for this property",
+            }
+        ),
+    ] = None
+    contentMediaType: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Media type of the property content",
+            }
+        ),
+    ] = None
+    maximum: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Maximum allowed value (inclusive)",
+            }
+        ),
+    ] = None
+    exclusiveMaximum: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Maximum allowed value (exclusive)",
+            }
+        ),
+    ] = None
+    minimum: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Minimum allowed value (inclusive)",
+            }
+        ),
+    ] = None
+    exclusiveMinimum: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Minimum allowed value (exclusive)",
+            }
+        ),
+    ] = None
+    pattern: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Regular expression pattern for validation",
+            }
+        ),
+    ] = None
+    maxItems: Annotated[
+        Optional[int],
+        Field(
+            json_schema_extra={
+                "description": "Maximum number of items in array",
+            }
+        ),
+    ] = None
+    minItems: Annotated[
+        Optional[int],
+        Field(
+            json_schema_extra={
+                "description": "Minimum number of items in array",
+            }
+        ),
+    ] = None
+    observedProperty: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Name of the observed property",
+            }
+        ),
+    ] = None
+    observedPropertyURI: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "URI of the observed property definition",
+            }
+        ),
+    ] = None
+    uom: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Unit of measurement",
+            }
+        ),
+    ] = None
+    uomURI: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "URI of the unit of measurement definition",
+            }
+        ),
+    ] = None
 
 
 class DimensionType(str, Enum):
@@ -214,94 +702,556 @@ class DimensionType(str, Enum):
 class DimensionExtent(BaseModel):
     """Extent information for a dimension"""
 
-    name: str
-    type: DimensionType
-    extent: list[Union[str, float, int]]  # [min, max] or list of discrete values
-    values: Optional[list[Union[str, float, int]]] = None  # Available discrete values
-    units: Optional[str] = None
-    description: Optional[str] = None
-    default: Optional[Union[str, float, int]] = None
+    name: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Name of the dimension",
+            }
+        ),
+    ]
+    type: Annotated[
+        DimensionType,
+        Field(
+            json_schema_extra={
+                "description": "Type of dimension (temporal, vertical, or custom)",
+            }
+        ),
+    ]
+    extent: Annotated[
+        list[Union[str, float, int]],
+        Field(
+            json_schema_extra={
+                "description": "Extent as [min, max] or list of discrete values",
+            }
+        ),
+    ]
+    values: Annotated[
+        Optional[list[Union[str, float, int]]],
+        Field(
+            json_schema_extra={
+                "description": "Available discrete values for this dimension",
+            }
+        ),
+    ] = None
+    units: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Units of measurement for this dimension",
+            }
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Description of this dimension",
+            }
+        ),
+    ] = None
+    default: Annotated[
+        Optional[Union[str, float, int]],
+        Field(
+            json_schema_extra={
+                "description": "Default value for this dimension",
+            }
+        ),
+    ] = None
 
 
 class Layer(BaseModel):
     """Layer definition within a tileset"""
 
-    id: str
-    title: Optional[str] = None
-    description: Optional[str] = None
-    keywords: Optional[str] = None
-    dataType: Optional[Union[DataType, str]] = None
-    geometryDimension: Optional[int] = None
-    featureType: Optional[str] = None
-    attribution: Optional[str] = None
-    license: Optional[str] = None
-    pointOfContact: Optional[str] = None
-    publisher: Optional[str] = None
-    theme: Optional[str] = None
-    crs: Optional[Union[str, CRSType]] = None
-    epoch: Optional[float] = None
-    minScaleDenominator: Optional[float] = None
-    maxScaleDenominator: Optional[float] = None
-    minCellSize: Optional[float] = None
-    maxCellSize: Optional[float] = None
-    maxTileMatrix: Optional[str] = None
-    minTileMatrix: Optional[str] = None
-    boundingBox: Optional[BoundingBox] = None
-    created: Optional[str] = None
-    updated: Optional[str] = None
-    style: Optional[Style] = None
-    geoDataClasses: Optional[list[str]] = None
-    propertiesSchema: Optional[dict[str, PropertySchema]] = None
-    dimensions: Optional[list[DimensionExtent]] = None
-    links: Optional[list[Link]] = None
+    id: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Identifier for this layer",
+            }
+        ),
+    ]
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this layer",
+            }
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Brief narrative description of this layer",
+            }
+        ),
+    ] = None
+    keywords: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Keywords associated with this layer",
+            }
+        ),
+    ] = None
+    dataType: Annotated[
+        Optional[Union[DataType, str]],
+        Field(
+            json_schema_extra={
+                "description": "Type of data in this layer (map, vector, coverage)",
+            }
+        ),
+    ] = None
+    geometryDimension: Annotated[
+        Optional[int],
+        Field(
+            json_schema_extra={
+                "description": "Dimension of the geometry (0=point, 1=line, 2=polygon, 3=volume)",
+            }
+        ),
+    ] = None
+    featureType: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Type of features in this layer",
+            }
+        ),
+    ] = None
+    attribution: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Attribution text for this layer",
+            }
+        ),
+    ] = None
+    license: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "License information for this layer",
+            }
+        ),
+    ] = None
+    pointOfContact: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Contact information for this layer",
+            }
+        ),
+    ] = None
+    publisher: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Publisher of this layer",
+            }
+        ),
+    ] = None
+    theme: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Theme or category of this layer",
+            }
+        ),
+    ] = None
+    crs: Annotated[
+        Optional[Union[str, CRSType]],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system for this layer",
+            }
+        ),
+    ] = None
+    epoch: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Epoch for coordinate reference system",
+            }
+        ),
+    ] = None
+    minScaleDenominator: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Minimum scale denominator for this layer",
+            }
+        ),
+    ] = None
+    maxScaleDenominator: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Maximum scale denominator for this layer",
+            }
+        ),
+    ] = None
+    minCellSize: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Minimum cell size for this layer",
+            }
+        ),
+    ] = None
+    maxCellSize: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Maximum cell size for this layer",
+            }
+        ),
+    ] = None
+    maxTileMatrix: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Maximum tile matrix identifier for this layer",
+            }
+        ),
+    ] = None
+    minTileMatrix: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Minimum tile matrix identifier for this layer",
+            }
+        ),
+    ] = None
+    boundingBox: Annotated[
+        Optional[BoundingBox],
+        Field(
+            json_schema_extra={
+                "description": "Bounding box of this layer",
+            }
+        ),
+    ] = None
+    created: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Creation date of this layer",
+            }
+        ),
+    ] = None
+    updated: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Last update date of this layer",
+            }
+        ),
+    ] = None
+    style: Annotated[
+        Optional[Style],
+        Field(
+            json_schema_extra={
+                "description": "Default style for this layer",
+            }
+        ),
+    ] = None
+    geoDataClasses: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "Geographic data classes for this layer",
+            }
+        ),
+    ] = None
+    propertiesSchema: Annotated[
+        Optional[dict[str, PropertySchema]],
+        Field(
+            json_schema_extra={
+                "description": "Schema definitions for layer properties",
+            }
+        ),
+    ] = None
+    dimensions: Annotated[
+        Optional[list[DimensionExtent]],
+        Field(
+            json_schema_extra={
+                "description": "Available dimensions for this layer",
+            }
+        ),
+    ] = None
+    links: Annotated[
+        Optional[list[Link]],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this layer",
+            }
+        ),
+    ] = None
 
 
 class CenterPoint(BaseModel):
     """Center point definition"""
 
-    coordinates: list[float]
-    crs: Optional[Union[str, CRSType]] = None
-    tileMatrix: Optional[str] = None
-    scaleDenominator: Optional[float] = None
-    cellSize: Optional[float] = None
+    coordinates: Annotated[
+        list[float],
+        Field(
+            json_schema_extra={
+                "description": "Coordinates of the center point",
+            }
+        ),
+    ]
+    crs: Annotated[
+        Optional[Union[str, CRSType]],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system for the center point",
+            }
+        ),
+    ] = None
+    tileMatrix: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Tile matrix identifier for the center point",
+            }
+        ),
+    ] = None
+    scaleDenominator: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Scale denominator at the center point",
+            }
+        ),
+    ] = None
+    cellSize: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Cell size at the center point",
+            }
+        ),
+    ] = None
 
 
 class TilesetSummary(BaseModel):
     """Summary of a tileset in a tilesets list"""
 
-    title: Optional[str] = None
-    description: Optional[str] = None
-    dataType: Union[DataType, str]  # "map", "vector", "coverage"
-    crs: Union[str, CRSType]
-    tileMatrixSetURI: Optional[str] = None
-    links: list[Link]
-    tileMatrixSetLimits: Optional[list[TileMatrixSetLimit]] = None
-    epoch: Optional[float] = None
-    layers: Optional[list[Layer]] = None
-    boundingBox: Optional[BoundingBox] = None
-    centerPoint: Optional[CenterPoint] = None
-    style: Optional[Style] = None
-    attribution: Optional[str] = None
-    license: Optional[str] = None
-    accessConstraints: Optional[str] = None
-    keywords: Optional[list[str]] = None
-    version: Optional[str] = None
-    created: Optional[str] = None
-    updated: Optional[str] = None
-    pointOfContact: Optional[str] = None
-    mediaTypes: Optional[list[str]] = None
+    title: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Human-readable title for this tileset",
+            }
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Brief narrative description of this tileset",
+            }
+        ),
+    ] = None
+    dataType: Annotated[
+        Union[DataType, str],
+        Field(
+            json_schema_extra={
+                "description": "Type of data contained in the tiles (map, vector, coverage)",
+            }
+        ),
+    ]
+    crs: Annotated[
+        Union[str, CRSType],
+        Field(
+            json_schema_extra={
+                "description": "Coordinate reference system used by this tileset",
+            }
+        ),
+    ]
+    tileMatrixSetURI: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "URI of the tile matrix set used by this tileset",
+            }
+        ),
+    ] = None
+    links: Annotated[
+        list[Link],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this tileset",
+            }
+        ),
+    ]
+    tileMatrixSetLimits: Annotated[
+        Optional[list[TileMatrixSetLimit]],
+        Field(
+            json_schema_extra={
+                "description": "Limits for tile matrices in this tileset",
+            }
+        ),
+    ] = None
+    epoch: Annotated[
+        Optional[float],
+        Field(
+            json_schema_extra={
+                "description": "Epoch for coordinate reference system",
+            }
+        ),
+    ] = None
+    layers: Annotated[
+        Optional[list[Layer]],
+        Field(
+            json_schema_extra={
+                "description": "Layers contained in this tileset",
+            }
+        ),
+    ] = None
+    boundingBox: Annotated[
+        Optional[BoundingBox],
+        Field(
+            json_schema_extra={
+                "description": "Bounding box of the tileset data",
+            }
+        ),
+    ] = None
+    centerPoint: Annotated[
+        Optional[CenterPoint],
+        Field(
+            json_schema_extra={
+                "description": "Center point of the tileset",
+            }
+        ),
+    ] = None
+    style: Annotated[
+        Optional[Style],
+        Field(
+            json_schema_extra={
+                "description": "Default style for this tileset",
+            }
+        ),
+    ] = None
+    attribution: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Attribution text for this tileset",
+            }
+        ),
+    ] = None
+    license: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "License information for this tileset",
+            }
+        ),
+    ] = None
+    accessConstraints: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Access constraints for this tileset",
+            }
+        ),
+    ] = None
+    keywords: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "Keywords associated with this tileset",
+            }
+        ),
+    ] = None
+    version: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Version of this tileset",
+            }
+        ),
+    ] = None
+    created: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Creation date of this tileset",
+            }
+        ),
+    ] = None
+    updated: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Last update date of this tileset",
+            }
+        ),
+    ] = None
+    pointOfContact: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Contact information for this tileset",
+            }
+        ),
+    ] = None
+    mediaTypes: Annotated[
+        Optional[list[str]],
+        Field(
+            json_schema_extra={
+                "description": "Supported media types for this tileset",
+            }
+        ),
+    ] = None
 
 
 class TilesetsList(BaseModel):
     """List of available tilesets"""
 
-    tilesets: list[TilesetSummary]
-    links: Optional[list[Link]] = None
+    tilesets: Annotated[
+        list[TilesetSummary],
+        Field(
+            json_schema_extra={
+                "description": "List of available tilesets",
+            }
+        ),
+    ]
+    links: Annotated[
+        Optional[list[Link]],
+        Field(
+            json_schema_extra={
+                "description": "Links related to this tilesets collection",
+            }
+        ),
+    ] = None
 
 
 class TilesLandingPage(BaseModel):
     """Landing page for a dataset's tiles"""
 
-    title: str
-    description: Optional[str] = None
-    links: list[Link]
+    title: Annotated[
+        str,
+        Field(
+            json_schema_extra={
+                "description": "Title of the tiles landing page",
+            }
+        ),
+    ]
+    description: Annotated[
+        Optional[str],
+        Field(
+            json_schema_extra={
+                "description": "Description of the tiles service",
+            }
+        ),
+    ] = None
+    links: Annotated[
+        list[Link],
+        Field(
+            json_schema_extra={
+                "description": "Links to tiles resources and metadata",
+            }
+        ),
+    ]


### PR DESCRIPTION
## Summary
- Refactor tileset metadata generation to use actual dataset properties instead of hardcoded values
- Add comprehensive FastAPI documentation to all OGC Tiles API models using Annotated fields with detailed descriptions

## Test plan
- [ ] Verify tileset metadata reflects actual dataset properties
- [ ] Check that FastAPI documentation displays field descriptions correctly
- [ ] Run existing tests to ensure no regressions
- [ ] Test API endpoints return properly documented responses

🤖 Generated with [opencode](https://opencode.ai)