### PR TITLE
Add ability to serve local datasets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
         run: uv run ty check src/ tests/
 
       - name: Run tests
-        run: uv run pytest tests --where=local --durations=10
+        run: uv run pytest tests --durations=10

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ uv run ty check
 Run the tests
 
 ```sh
-uv run pytest tests --where=local
+uv run pytest tests
+```
+
+Run setup tests (create local datasets, these can be deployed using the CLI)
+
+```sh
+uv run pytest --setup
 ```
 
 ## CLI Usage
@@ -64,6 +70,9 @@ xpublish-tiles --port 9000 --dataset air
 
 # Serve Arraylake dataset with specific branch and group
 xpublish-tiles --dataset earthmover-public/aifs-outputs --branch main --group 2025-04-01/12z --cache
+
+# Serve locally stored data created using `uv run pytest --setup`
+uv run xpublish-tiles --dataset=local://ifs
 ```
 
 Once running, the server provides:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ minversion = "7"
 testpaths = ["tests", "integration_tests"]
 log_cli_level = "INFO"
 xfail_strict = true
-addopts = ["-ra", "--strict-config", "--strict-markers", "-n", "auto"]
+addopts = ["-ra", "--strict-config", "--strict-markers", "-n", "auto", "--dist=loadgroup"]
 
 [tool.ruff]
 line-length = 90

--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -558,7 +558,11 @@ def guess_grid_system(ds: xr.Dataset, name: str) -> GridSystem:
     try:
         grid = _guess_grid_for_dataset(ds.cf[[name]])
     except RuntimeError:
-        grid = _guess_grid_for_dataset(ds)
+        try:
+            grid = _guess_grid_for_dataset(ds)
+        except RuntimeError:
+            ds = ds.cf.guess_coord_axis()
+            grid = _guess_grid_for_dataset(ds)
 
     grid.Z = _guess_z_dimension(ds.cf[name])
 

--- a/tests/test_create_datasets.py
+++ b/tests/test_create_datasets.py
@@ -13,8 +13,6 @@ from xpublish_tiles.testing.datasets import (
     Dataset,
 )
 
-ARRAYLAKE_REPO = "earthmover-integration/tiles-datasets-develop"
-
 
 @pytest.fixture(
     params=[
@@ -32,12 +30,14 @@ def dataset(request):
     return request.param
 
 
-def test_create(dataset: Dataset, repo, where: str, prefix: str, request) -> None:
+# This test runs first when --setup is passed. The xdist_group ensures it completes
+# before other tests run in parallel.
+@pytest.mark.xdist_group(name="repo_creation")
+def test_create_local_dataset(dataset: Dataset, repo, request) -> None:
     if not request.config.getoption("--setup"):
-        pytest.skip("test_create only runs when --setup flag is provided")
+        pytest.skip("test_create_local_dataset only runs when --setup flag is provided")
 
     ds = dataset.create()
     session = repo.writable_session("main")
-
     to_icechunk(ds, session, group=dataset.name, mode="w")
     session.commit(f"wrote {dataset.name!r}")

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -17,7 +17,14 @@ from xpublish_tiles.grids import (
     Rectilinear,
     guess_grid_system,
 )
-from xpublish_tiles.testing.datasets import EU3035, FORECAST, HRRR, HRRR_CRS_WKT, ROMSDS
+from xpublish_tiles.testing.datasets import (
+    EU3035,
+    FORECAST,
+    HRRR,
+    HRRR_CRS_WKT,
+    IFS,
+    ROMSDS,
+)
 from xpublish_tiles.testing.tiles import TILES
 
 # FIXME: add tests for datasets with latitude, longitude but no attrs
@@ -26,6 +33,23 @@ from xpublish_tiles.testing.tiles import TILES
 @pytest.mark.parametrize(
     "ds, array_name, expected",
     (
+        (
+            IFS.create(),
+            "foo",
+            Rectilinear(
+                crs=CRS.from_epsg(4326),
+                bbox=BBox(
+                    west=-180,
+                    south=-90,
+                    east=180,
+                    north=90,
+                ),
+                X="longitude",
+                Y="latitude",
+                Z=None,
+                indexes=(),  # type: ignore[arg-type]
+            ),
+        ),
         (
             FORECAST,
             "sst",


### PR DESCRIPTION
- removes the arraylake stuff
- allows serving local data with `uv run xpublish-tiles --dataset=local://ifs`
- create those datasets with `uv run pytest --setup`
- fixes IFS grid detection