### PR TITLE
Avoid useless rewriting when transforming coordinates EAR-2087

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 """Test configuration management with donfig."""
 
+import numpy as np
+
+import xarray as xr
 from xpublish_tiles.config import config
 from xpublish_tiles.lib import get_transform_chunk_size
 
@@ -29,14 +32,18 @@ def test_config_with_context_manager():
     assert config.get("transform_chunk_size") == 1024
 
 
-def test_dynamic_config_in_lib():
+def test_get_transform_chunk_size():
     """Test that the dynamic config functions work correctly."""
     # Test defaults
-    assert get_transform_chunk_size() == (1024, 1024)
+    da = xr.DataArray(np.ones((1024, 1024)), dims=("x", "y"))
+    assert get_transform_chunk_size(da, "x", "y") == (1024, 1024)
 
     # Test with context manager
     with config.set(transform_chunk_size=256):
-        assert get_transform_chunk_size() == (256, 256)
+        assert get_transform_chunk_size(da, "x", "y") == (64, 1024)
+
+    da = xr.DataArray(np.ones((2048, 2048)), dims=("x", "y"))
+    assert get_transform_chunk_size(da, "x", "y") == (512, 2048)
 
 
 def test_detect_approx_rectilinear_config():


### PR DESCRIPTION
Results from profiling `uv run memray run --native -m xpublish_tiles.cli.main --port 8999 --dataset local://utm50s_hires --spy`

Less impact than expected but we still reduce mem allocation by 1GB

### main
```
📏 Total allocations: 3525466
📦 Total memory allocated: 25.984GB
📊 Histogram of allocation size:
	min: 1.000B
	----------------------------------------------
	< 6.594MB  :    2868 ▇
	< 46.941MB :     252 ▇
	<=334.155MB:      62 ▇
	----------------------------------------------
	max: 334.155MB

📂 Allocator type distribution:
	 MALLOC: 3156214
	 REALLOC: 253379
	 CALLOC: 63722
	 MMAP: 40382
	 POSIX_MEMALIGN: 11545
	 ALIGNED_ALLOC: 224

🥇 Top 5 largest allocating locations (by size):
	- as_numpy_array_wrapper:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/zarr/core/buffer/cpu.py:220 -> 6.963GB
	- <stack trace unavailable> -> 4.875GB
	- empty:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/zarr/core/buffer/cpu.py:167 -> 4.216GB
	- move_axes:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/numbagg/utils.py:17 -> 3.825GB
	- _copytobuffer:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/pyproj/utils.py:130 -> 1.164GB
```

### this PR
```
📏 Total allocations: 3497501
📦 Total memory allocated: 24.918GB
📊 Histogram of allocation size:
	min: 1.000B
	----------------------------------------------
	< 6.594MB  :    2688 ▇
	< 46.941MB :     154 ▇
	<=334.155MB:      62 ▇
	----------------------------------------------
	max: 334.155MB

📂 Allocator type distribution:
	 MALLOC: 3145258
	 REALLOC: 247850
	 CALLOC: 52390
	 MMAP: 40325
	 POSIX_MEMALIGN: 11454
	 ALIGNED_ALLOC: 224

🥇 Top 5 largest allocating locations (by size):
	- as_numpy_array_wrapper:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/zarr/core/buffer/cpu.py:220 -> 6.963GB
	- <stack trace unavailable> -> 4.819GB
	- empty:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/zarr/core/buffer/cpu.py:167 -> 4.216GB
	- move_axes:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/numbagg/utils.py:17 -> 3.825GB
	- __call__:/Users/deepak/repos/xpublish-tiles/.venv/lib/python3.11/site-packages/llvmlite/binding/ffi.py:197 -> 759.880MB
```