### PR TITLE
skip spatial_ref variable in `extract_dataset_extents` [EAR-2233]

### DIFF
--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -143,6 +143,8 @@ def extract_dataset_extents(
         ds = dataset
 
     for var in ds.data_vars:
+        if var == "spatial_ref":
+            continue  # Skip spatial_ref variable
         dimensions = extract_dimension_extents(ds, var)
         for dim in dimensions:
             # Use the first occurrence of each dimension name


### PR DESCRIPTION
**Do not merge this PR as is.**

This hack fixes the issue with this dataset: https://app.earthmover.io/earthmover-demos/sentinel-datacube-South-America-3-icechunk/data-access/main?method=tiles

The problem is that the dataset has a `spatial_ref` variable set, and this appears in the list of data_vars: https://app.earthmover.io/earthmover-demos/sentinel-datacube-South-America-3-icechunk/array/main/spatial_ref

`spatial_ref` has the following attributes

```json
{
  "GeoTransform": "-82.0 0.0002777777777777778 0.0 13.0 0.0 -0.0002777777777777778",
  "crs_wkt": "GEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],USAGE[SCOPE[\"Horizontal component of 3D system.\"],AREA[\"World.\"],BBOX[-90,-180,90,180]],ID[\"EPSG\",4326]]",
  "geographic_crs_name": "WGS 84",
  "grid_mapping_name": "latitude_longitude",
  "horizontal_datum_name": "World Geodetic System 1984 ensemble",
  "inverse_flattening": 298.257223563,
  "longitude_of_prime_meridian": 0,
  "prime_meridian_name": "Greenwich",
  "reference_ellipsoid_name": "WGS 84",
  "semi_major_axis": 6378137,
  "semi_minor_axis": 6356752.314245179,
  "spatial_ref": "GEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],USAGE[SCOPE[\"Horizontal component of 3D system.\"],AREA[\"World.\"],BBOX[-90,-180,90,180]],ID[\"EPSG\",4326]]"
}
```

This is automatically created by the `odc.geo.xr.xr_zeros` function: https://odc-geo.readthedocs.io/en/latest/_api/odc.geo.xr.xr_zeros.html

I am not exactly sure what convention this is conforming to.

Rather than special casing this variable, we should
- [ ] add better logic to the `extract_dimension_extents` function so that it doesn't fail when it encounters `spatial_ref`
- [ ] add a test for this type of dataset