### PR TITLE
Ensure colormap is in tilejson URLs

### DIFF
--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -5,6 +5,8 @@ import logging
 import time
 from enum import Enum
 from typing import Annotated
+from urllib.parse import quote
+import json
 
 import morecantile
 import structlog
@@ -311,6 +313,9 @@ class TilesPlugin(Plugin):
             # Append optional color scale range
             if query.colorscalerange:
                 url_template = f"{url_template}&colorscalerange={query.colorscalerange[0]:g},{query.colorscalerange[1]:g}"
+
+            if query.colormap:
+                url_template = f"{url_template}&colormap={quote(json.dumps(query.colormap))}"
 
             # Append selectors
             if selectors:


### PR DESCRIPTION
Previously the `colormap` query arg wasn't passed down when generating the tilejson URLs which meant the default style was being applied instead of using the colormap provided.

I also noticed there is no test for the tilejson endpoint in https://github.com/earth-mover/xpublish-tiles/blob/fd6db7e981a71ca24b31a25a5b75d78aaad3d514/tests/test_xpublish/test_tiles/test_tiles_plugin.py#L767, that was probably why this was missed :)

Thanks for adding support for custom colormaps in #132 @rabernat :) Could this be added for WMS too or would that break the URL spec?