### PR TITLE
Support icechunk s3_storage

### DIFF
--- a/src/xpublish_tiles/cli/main.py
+++ b/src/xpublish_tiles/cli/main.py
@@ -92,11 +92,11 @@ def get_dataset_for_name(
         try:
             import icechunk
 
-            if 's3://' in repo_path:
+            if "s3://" in repo_path:
                 storage = icechunk.s3_storage(
-                    bucket=repo_path.removeprefix('s3://').split('/')[0],
-                    prefix='/'.join(repo_path.removeprefix('s3://').split('/')[1:])
-                    )
+                    bucket=repo_path.removeprefix("s3://").split("/")[0],
+                    prefix="/".join(repo_path.removeprefix("s3://").split("/")[1:]),
+                )
             else:
                 storage = icechunk.local_filesystem_storage(repo_path)
 


### PR DESCRIPTION
Adds support for exposing an icechunk store in S3 with something like

```bash
xpublish-tiles --dataset icechunk://s3://bucket_name/path/to/icechunk/  --group group_name
```

This change helped me get off the ground with playing around with this package. Many thanks for publishing it!