### PR TITLE
Rework categorical colormapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,43 @@ Here `lat[lat]` means a coordinate variable named `lat` with one dimension named
 We attempt to require as little metadata as possible, and attempts to infer as much as possible. However, it is *always* better
 for you to annotate your dataset using the CF & ACDD conventions as well as possible.
 
+### Categorical Data support
+
+By default all data is treated as continuous. Discrete data are assumed to be encoded with the CF flag variable convention i.e., arrays with the `flag_values` and `flag_meanings`
+attributes are treated as discrete categorical data by the rendering pipeline.
+
 ### Custom Colormaps
 
+> [!IMPORTANT]
+> At the moment RGBA colors are not supported in colormaps because of this [upstream datashader issue](https://github.com/holoviz/datashader/issues/1404).
+
 Custom colormaps can be provided using the `colormap` parameter. When using a custom colormap, you must set `style=raster/custom`.
+
+**Continuous data**
 
 The colormap is a JSON-encoded dictionary with:
 - **Keys**: String integers from "0" to "255" (not data values)
 - **Values**: Hex color codes in the format `#RRGGBB`
 
 > [!IMPORTANT]
-> Custom colormaps must include both "0" and "255" as keys. These colormaps must have keys that are "0" and "255", not data values. The data value is rescaled by `colorscalerange` to 0→1; the colormap is rescaled from 0→255 to 0→1 and then applied to the scaled 0→1 data.
+> Custom colormaps for continuous data must include both "0" and "255" as keys. These colormaps must have keys that are "0" and "255", not data values. The data value is rescaled by `colorscalerange` to 0→1; the colormap is rescaled from 0→255 to 0→1 and then applied to the scaled 0→1 data.
+
+**Categorical data**
+
+The colormap is a JSON-encoded dictionary with:
+- **Keys**: Data values that match the values of the `flag_values` attribute of the array.
+- **Values**: Hex color codes in the format `#RRGGBB`
+
+Alternatively the `flag_colors` attribute can be set on the array. Its value must be a string containing space delimited hex colors of the same length
+as the corresponding `flag_meanings` and `flag_values` attributes. For example
+
+```
+land_cover:flag_values = 1, 2, 3, 4, 5, 6;
+land_cover:flag_meanings = "Broadleaf_Woodland Coniferous_Woodland Arable_and_Horticulture Improved_Grassland Rough_Grassland Neutral_Grassland" ;
+land_cover:flag_colors = "#FF0000 #006600 #732600 #00FF00 #FAAA00 #7FE57F" ;
+```
+
+See the [ncWMS convention docs on Categorical Data](https://web.archive.org/web/20240729161558/https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/05-data_formats.html#vector) for more.
 
 ### Dimension selection with methods
 

--- a/src/xpublish_tiles/render/raster.py
+++ b/src/xpublish_tiles/render/raster.py
@@ -1,5 +1,4 @@
 import io
-from collections.abc import Hashable, Sequence
 from typing import TYPE_CHECKING, cast
 
 import datashader as dsh  # type: ignore
@@ -15,7 +14,11 @@ from scipy.interpolate import NearestNDInterpolator
 
 import xarray as xr
 from xpublish_tiles.grids import Curvilinear, GridSystem2D, Triangular
-from xpublish_tiles.lib import MissingParameterError, create_colormap_from_dict
+from xpublish_tiles.lib import (
+    MissingParameterError,
+    create_colormap_from_dict,
+    create_listed_colormap_from_dict,
+)
 from xpublish_tiles.logger import get_context_logger, log_duration
 from xpublish_tiles.render import Renderer, register_renderer, render_error_image
 from xpublish_tiles.types import (
@@ -80,41 +83,6 @@ def nearest_on_uniform_grid_quadmesh(
     )
     res = cvs.quadmesh(da, x=Xdim, y=Ydim, agg=dsh.reductions.first(cast(str, da.name)))
     return res
-
-
-def create_listed_colormap_from_dict(
-    colormap_dict: dict[str, str], flag_values: Sequence[Hashable]
-) -> mcolors.ListedColormap:
-    """Create a matplotlib ListedColormap from a dictionary of flag_value->color mappings.
-
-    For categorical data, the colormap must have exactly as many entries as flag_values.
-    Every key in the colormap must correspond to a flag_value.
-    Keys should be string representations of the flag values, and values should be hex colors.
-    """
-    # Validate that all colormap keys are in flag_values
-    flag_values_str = {str(v) for v in flag_values}
-    colormap_keys = set(colormap_dict.keys())
-
-    # Check for colormap keys that don't correspond to any flag_value
-    invalid_keys = colormap_keys - flag_values_str
-    if invalid_keys:
-        raise ValueError(
-            f"colormap contains keys not in flag_values: {sorted(invalid_keys)}. "
-            f"Valid flag_values: {sorted(flag_values_str)}"
-        )
-
-    # Check for flag_values that don't have colormap entries
-    missing_keys = flag_values_str - colormap_keys
-    if missing_keys:
-        raise ValueError(
-            f"colormap is missing entries for flag_values: {sorted(missing_keys)}. "
-            f"All flag_values must have corresponding colors."
-        )
-
-    # Build colormap in the order of flag_values
-    colors = [colormap_dict[str(flag_value)] for flag_value in flag_values]
-
-    return mcolors.ListedColormap(colors)
 
 
 @register_renderer
@@ -254,25 +222,23 @@ class DatashaderRasterRenderer(Renderer):
                 )
         elif isinstance(context.datatype, DiscreteData):
             kwargs = {}
+            flag_values = context.datatype.values
             # Custom colormap overrides flag_colors
             if colormap is not None:
-                kwargs["cmap"] = create_listed_colormap_from_dict(
-                    colormap, context.datatype.values
-                )
-                kwargs["span"] = (
-                    min(context.datatype.values),
-                    max(context.datatype.values),
+                kwargs["color_key"] = create_listed_colormap_from_dict(
+                    colormap, flag_values
                 )
             elif context.datatype.colors is not None:
                 kwargs["color_key"] = dict(
                     zip(context.datatype.values, context.datatype.colors, strict=True)
                 )
             else:
-                kwargs["cmap"] = mpl.colormaps.get_cmap(variant)
-                kwargs["span"] = (
-                    min(context.datatype.values),
-                    max(context.datatype.values),
-                )
+                minv = min(flag_values)
+                maxv = max(flag_values)
+                cmap = mpl.colormaps.get_cmap(variant)
+                kwargs["color_key"] = {
+                    v: mcolors.to_hex(cmap((v - minv) / maxv)) for v in flag_values
+                }
             with np.errstate(invalid="ignore"):
                 shaded = tf.shade(mesh, how="linear", **kwargs)
         else:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,7 @@
 import pytest
 from pyproj import CRS
 
+from xpublish_tiles.lib import create_listed_colormap_from_dict
 from xpublish_tiles.types import ImageFormat
 from xpublish_tiles.validators import (
     validate_colormap,
@@ -319,23 +320,19 @@ class TestValidateColormap:
 
 class TestCategoricalColormap:
     def test_create_listed_colormap_valid(self):
-        """Test creating a ListedColormap with valid categorical colormap."""
-        from xpublish_tiles.render.raster import create_listed_colormap_from_dict
-
+        """Test creating a color_key dictionary with valid categorical colormap."""
         colormap_dict = {
             "0": "#ff0000",
             "1": "#00ff00",
             "2": "#0000ff",
         }
         flag_values = [0, 1, 2]
-        cmap = create_listed_colormap_from_dict(colormap_dict, flag_values)
-        assert cmap.N == 3
-        assert len(cmap.colors) == 3
+        color_key = create_listed_colormap_from_dict(colormap_dict, flag_values)
+        assert len(color_key) == 3
+        assert color_key == {0: "#ff0000", 1: "#00ff00", 2: "#0000ff"}
 
     def test_create_listed_colormap_missing_flag_value(self):
         """Test that missing flag_value raises error."""
-        from xpublish_tiles.render.raster import create_listed_colormap_from_dict
-
         colormap_dict = {
             "0": "#ff0000",
             "1": "#00ff00",
@@ -349,8 +346,6 @@ class TestCategoricalColormap:
 
     def test_create_listed_colormap_invalid_key(self):
         """Test that keys not in flag_values raise error."""
-        from xpublish_tiles.render.raster import create_listed_colormap_from_dict
-
         colormap_dict = {
             "0": "#ff0000",
             "1": "#00ff00",
@@ -365,8 +360,6 @@ class TestCategoricalColormap:
 
     def test_create_listed_colormap_non_consecutive_flag_values(self):
         """Test that non-consecutive flag_values work correctly."""
-        from xpublish_tiles.render.raster import create_listed_colormap_from_dict
-
         # flag_values don't have to be consecutive
         colormap_dict = {
             "0": "#ff0000",
@@ -374,6 +367,6 @@ class TestCategoricalColormap:
             "10": "#0000ff",
         }
         flag_values = [0, 5, 10]
-        cmap = create_listed_colormap_from_dict(colormap_dict, flag_values)
-        assert cmap.N == 3
-        assert len(cmap.colors) == 3
+        color_key = create_listed_colormap_from_dict(colormap_dict, flag_values)
+        assert len(color_key) == 3
+        assert color_key == {0: "#ff0000", 5: "#00ff00", 10: "#0000ff"}


### PR DESCRIPTION
1. Now we always pass `color_key` to trigger discrete coloring.
2. This also has the implication that any value outside valid flag_values is transparent in all cases.