### PR TITLE
support google cloud storage

### DIFF
--- a/src/xpublish_tiles/cli/main.py
+++ b/src/xpublish_tiles/cli/main.py
@@ -92,9 +92,19 @@ def get_dataset_for_name(
 
         try:
             if "s3://" in repo_path:
+                path_parts = repo_path.removeprefix("s3://").split("/")
                 storage = icechunk.s3_storage(
-                    bucket=repo_path.removeprefix("s3://").split("/")[0],
-                    prefix="/".join(repo_path.removeprefix("s3://").split("/")[1:]),
+                    bucket=path_parts[0],
+                    prefix="/".join(path_parts[1:]),
+                )
+            elif repo_path.startswith(("gs://", "gcs://")):
+                path_parts = (
+                    repo_path.removeprefix("gs://").removeprefix("gcs://").split("/")
+                )
+                storage = icechunk.gcs_storage(
+                    bucket=path_parts[0],
+                    prefix="/".join(path_parts[1:]),
+                    from_env=True,
                 )
             else:
                 storage = icechunk.local_filesystem_storage(repo_path)


### PR DESCRIPTION
I had to add this to be able to use xpublish-tiles with Google Cloud Storage. Just using the library for the first time, apologies if this is misplaced!

After adding this, I was able to run with:
```bash
uv run xpublish-tiles --dataset "local://gs://bucket/repo::"
```

I don't really understand the `local://` thing, so likely this is a bit of a kludge...

NB: the changes to the s3 branch are just a little clean-up to keep the two consistent.