### PR TITLE
Speed up metadata routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "cf-xarray>=0.10.11",
+    "cf-xarray>=0.11.1",
     "cftime>=1.6.4.post1",
     "datashader>=0.19",
     "donfig>=0.8.0",

--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -2625,14 +2625,13 @@ class CubedSphere(FacetedGridSystem):
         face_dim: str = "nf",
     ) -> Self:
         face_size = ds.sizes[face_dim]
-        # Keep only the 2D lon/lat aux coords; Curvilinear.from_dataset does
-        # a cf-xarray axis scan so trimming down avoids pulling in unrelated
-        # variables and their attrs. Also keep vertex-mesh corner variables
-        # (resolved via SGRID node_coordinates or the GMAO `corner_*`
-        # convention) so Curvilinear can use true shared-vertex corners
-        # instead of per-face extrapolation, plus the SGRID grid_topology
-        # variable (a scalar that survives the per-face isel) so per-face
-        # Curvilinear.from_dataset can re-resolve via SGRID.
+        # Keep only the 2D lon/lat aux coords
+        # - Curvilinear.from_dataset does a cf-xarray axis scan so trimming down avoids pulling in unrelated
+        #   variables and their attrs.
+        # - Use vertex-mesh corner variables (resolved via SGRID node_coordinates or the GMAO `corner_*`
+        #   convention) so Curvilinear can use true shared-vertex corners
+        # - Keep the SGRID grid_topology variable (a scalar that survives the per-face isel) so per-face
+        #   Curvilinear.from_dataset can re-resolve via SGRID.
         corner_x_name = _resolve_corner_name(ds, Xname)
         corner_y_name = _resolve_corner_name(ds, Yname)
         keep = [Xname, Yname]

--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -33,6 +33,7 @@ from xpublish_tiles.lib import (
     is_degree_geographic,
     round_bbox,
     sync_load_async,
+    transformer_from_crs,
     unwrap,
 )
 from xpublish_tiles.logger import get_context_logger, log_duration
@@ -1168,6 +1169,10 @@ class GridSystem(ABC):
     dXmin: float = 0
     dYmin: float = 0
 
+    _bbox_xform_cache: dict[str, tuple[float, float, float, float]] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+
     @classmethod
     @abstractmethod
     def from_dataset(cls, ds: xr.Dataset, crs: CRS, Xname: str, Yname: str) -> Self:
@@ -1178,6 +1183,22 @@ class GridSystem(ABC):
     def dims(self) -> set[str]:
         """Return the set of dimension names for this grid system."""
         pass
+
+    def transform_bbox(self, target_crs: str) -> tuple[float, float, float, float]:
+        """Return ``self.bbox`` transformed into ``target_crs``.
+
+        Many variables share a grid, so the result is cached per ``target_crs``
+        on the instance to collapse ``transform_bounds`` calls.
+        """
+        cached = self._bbox_xform_cache.get(target_crs)
+        if cached is not None:
+            return cached
+        transformer = transformer_from_crs(crs_from=self.crs, crs_to=target_crs)
+        bounds = transformer.transform_bounds(
+            self.bbox.west, self.bbox.south, self.bbox.east, self.bbox.north
+        )
+        self._bbox_xform_cache[target_crs] = bounds
+        return bounds
 
     def assign_index(self, da: xr.DataArray) -> xr.DataArray:
         return da
@@ -2188,6 +2209,7 @@ class Triangular(GridSystem):
                 lon_spans_globe=self.lon_spans_globe,
             ),
         )
+        self._bbox_xform_cache = {}
 
     @property
     def Xdim(self) -> str:
@@ -2319,6 +2341,7 @@ class Healpix(GridSystem):
         self.bbox = bbox
         self.alternates = ()
         self.cell_ids = cell_ids
+        self._bbox_xform_cache = {}
 
         depth = int(index.grid_info.level)
         # straddle the 180° antimeridian with a hairline zone.

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -308,9 +308,11 @@ async def extract_variable_bounding_box(
         # Get the grid system for this variable (run in thread to avoid blocking)
         grid = await async_run(guess_grid_system, dataset, variable_name)
 
-        # Convert target CRS to string format for transformer
+        # ``morecantile.CRS.srs`` returns the cached pyproj ``_srs`` string;
+        # ``to_epsg`` round-trips through the EPSG database and is unexpectedly
+        # expensive when called per variable.
         if isinstance(target_crs, morecantile.models.CRS):
-            target_crs_str = target_crs.to_epsg() or target_crs.to_wkt() or ""
+            target_crs_str = target_crs.srs
         else:
             target_crs_str = target_crs
 

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -29,6 +29,12 @@ from xpublish_tiles.xpublish.tiles.types import (
     TilesetSummary,
 )
 
+# Result of ``allowed_styles`` is dataset-wide and stable, but the body
+# loops every data var and pays a ``guess_grid_system`` cache-miss for each
+# unique dim signature. Memoize per dataset so repeat /tiles/ requests skip
+# all of that.
+_ALLOWED_STYLES_CACHE: dict[str, list[str]] = {}
+
 
 def allowed_styles(dataset: Dataset | None = None) -> list[str]:
     """Return the style IDs supported by ``dataset``'s grid.
@@ -36,17 +42,28 @@ def allowed_styles(dataset: Dataset | None = None) -> list[str]:
     Healpix and Faceted grids (e.g. cubed sphere) only support ``polygons``;
     every other grid supports both ``raster`` and ``polygons``.
     """
-    if dataset is not None:
-        for var_name, var_data in dataset.data_vars.items():
-            if var_data.ndim == 0:
-                continue
-            try:
-                grid = guess_grid_system(dataset, str(var_name))
-            except Exception:
-                continue
-            if isinstance(grid, (Healpix, FacetedGridSystem)):
-                return ["polygons"]
-    return ["raster", "polygons"]
+    if dataset is None:
+        return ["raster", "polygons"]
+
+    xpublish_id = dataset.attrs.get("_xpublish_id")
+    if xpublish_id is not None and xpublish_id in _ALLOWED_STYLES_CACHE:
+        return _ALLOWED_STYLES_CACHE[xpublish_id]
+
+    result = ["raster", "polygons"]
+    for var_name, var_data in dataset.data_vars.items():
+        if var_data.ndim == 0:
+            continue
+        try:
+            grid = guess_grid_system(dataset, str(var_name))
+        except Exception:
+            continue
+        if isinstance(grid, (Healpix, FacetedGridSystem)):
+            result = ["polygons"]
+            break
+
+    if xpublish_id is not None:
+        _ALLOWED_STYLES_CACHE[xpublish_id] = result
+    return result
 
 
 def get_styles(dataset: Dataset | None = None) -> list[Style]:

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -10,7 +10,6 @@ from xarray import Dataset
 from xpublish_tiles.grids import FacetedGridSystem, Healpix, guess_grid_system
 from xpublish_tiles.lib import VariableNotFoundError, async_run
 from xpublish_tiles.logger import logger
-from xpublish_tiles.pipeline import transformer_from_crs
 from xpublish_tiles.render import RenderRegistry
 from xpublish_tiles.xpublish.tiles.tile_matrix import (
     TILE_MATRIX_SET_SUMMARIES,
@@ -316,14 +315,7 @@ async def extract_variable_bounding_box(
         else:
             target_crs_str = target_crs
 
-        # Transform bounds to target CRS
-        transformer = transformer_from_crs(crs_from=grid.crs, crs_to=target_crs_str)
-        transformed_bounds = transformer.transform_bounds(
-            grid.bbox.west,
-            grid.bbox.south,
-            grid.bbox.east,
-            grid.bbox.north,
-        )
+        transformed_bounds = grid.transform_bbox(target_crs_str)
 
         return BoundingBox(
             lowerLeft=[transformed_bounds[0], transformed_bounds[1]],

--- a/uv.lock
+++ b/uv.lock
@@ -550,14 +550,14 @@ wheels = [
 
 [[package]]
 name = "cf-xarray"
-version = "0.10.11"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/78/f4f38e7ea6221773ea48d85c00d529b1fdc7378a1a1b77c2b77661446a0b/cf_xarray-0.10.11.tar.gz", hash = "sha256:e10ee37b0ed3ba36f42346360f2bc070c690ddc73bb9dcdd9463b3a221453be3", size = 686693, upload-time = "2026-02-03T19:17:42.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/03/c7e3b996e404103b540427160f14df063fd31a9859df2b198b48ebf536ff/cf_xarray-0.11.1.tar.gz", hash = "sha256:c5935d7bf6d95a7229ba9741501d8491164d35f0e5b5d366c2dce302ae742276", size = 691204, upload-time = "2026-05-12T20:58:52.839Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/ce/5c4f4660da5521d90bea62cdf8396d7e4ce4a00513e218d267b97f9ea453/cf_xarray-0.10.11-py3-none-any.whl", hash = "sha256:c47fff625766c69a66fedef368d9787acb0819b32d8bd022f8b045089b42109a", size = 78421, upload-time = "2026-02-03T19:17:40.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/2d4f04e27c2481fd697522340df04f3a278dfe9a1f13292b2f9e39b98a44/cf_xarray-0.11.1-py3-none-any.whl", hash = "sha256:b55c77af7bc5c0768a65ab6eafef89646e5cbf003a12ec37513983565e25f888", size = 79377, upload-time = "2026-05-12T20:58:51.016Z" },
 ]
 
 [[package]]
@@ -5166,7 +5166,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.15" },
     { name = "cachetools", specifier = ">=5.5.2" },
-    { name = "cf-xarray", specifier = ">=0.10.11" },
+    { name = "cf-xarray", specifier = ">=0.11.1" },
     { name = "cftime", specifier = ">=1.6.4.post1" },
     { name = "datashader", git = "https://github.com/holoviz/datashader.git?rev=2ff83af86022f667015488d2b2d602409b931cf4" },
     { name = "donfig", specifier = ">=0.8.0" },


### PR DESCRIPTION
A collection of changes to speed up metadata routes.
- Use `morecantile.CRS.srs` to speedup proj
- Cache transformed bbox on `GridSystem`. This is yet another indication that we need an abstraction around GridSystem
- Cache allowed_styles (which in general will end up parsing a GridSystem)
- Grab upstream cf-xarray improvements.

Some of these changes are in-the-weeds but it's a hot path for Arraylake's Data Access tab