### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,10 +9,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,11 @@ jobs:
       with:
         persist-credentials: false
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        python-version: "3.12"
+    - run: python -m pip install pre-commit
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,19 +21,23 @@ jobs:
 
       - name: set target
         id: set_target
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event.inputs.tag }}"  != "" ]]
+          if [[ "$INPUT_TAG"  != "" ]]
           then
-            echo "GITHUB_REF=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "GITHUB_REF=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
-             echo "GITHUB_REF=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+             echo "GITHUB_REF=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{steps.set_target.outputs.GITHUB_REF}}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         name: Install Python
         with:
           python-version: "3.12"
@@ -53,7 +57,7 @@ jobs:
           hatch build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: ./dist
           print-hash: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: python (shard ${{ matrix.shard }}/${{ strategy.job-total }})
@@ -19,10 +22,12 @@ jobs:
         shard: [1, 2, 3, 4]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
         with:
           enable-cache: true
 
@@ -35,11 +40,14 @@ jobs:
 
       # To debug snapshot test failures run with --debug-visual-save and download the artifact zip created in the next step.
       - name: Run tests with coverage
-        run: uv run pytest tests --cov=src/xpublish_tiles --cov-report=xml --cov-report=term-missing --durations=10 -nauto --splits=${{ strategy.job-total }} --group=${{ matrix.shard }} --splitting-algorithm=least_duration
+        env:
+          SPLITS: ${{ strategy.job-total }}
+          GROUP: ${{ matrix.shard }}
+        run: uv run pytest tests --cov=src/xpublish_tiles --cov-report=xml --cov-report=term-missing --durations=10 -nauto --splits="$SPLITS" --group="$GROUP" --splitting-algorithm=least_duration
 
       - name: Upload debug visual images on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: debug-visual-images-shard-${{ matrix.shard }}
           path: debug_visual_diff_*.png
@@ -47,7 +55,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -57,10 +65,12 @@ jobs:
   test-import-with-base-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           enable-cache: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,10 @@ repos:
       - id: actionlint
         files: ".github/workflows/"
         args: ["-ignore", "SC1090", "-ignore", "SC2046", "-ignore", "SC2086", "-ignore", "SC2129", "-ignore", "SC2155"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
   - repo: https://github.com/codespell-project/codespell
     # Configuration for codespell is in .codespellrc
     rev: v2.4.1


### PR DESCRIPTION
## Summary
- Pins all actions in `test.yml`, `pre-commit.yml`, and `publish.yml` to full-length commit SHAs (with `# vX` comments so Dependabot can still bump them) to satisfy the org policy.
- Adds [zizmor](https://github.com/zizmorcore/zizmor) as a pre-commit hook to prevent regressions.
- Fixes the other findings zizmor surfaced: `persist-credentials: false` on each `checkout`, top-level `permissions: contents: read`, and `${{ ... }}` expansions moved into `env` blocks in `run:` steps.

## Test plan
- [ ] CI: pre-commit job (now runs zizmor)
- [ ] CI: run-tests matrix passes with env-var `--splits` / `--group`

🤖 Generated with [Claude Code](https://claude.com/claude-code)