### PR TITLE
fix: select cubed-sphere cells crossing the 0/360 longitude seam

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.12"
 dependencies = [
     "cf-xarray>=0.11.1",
     "cftime>=1.6.4.post1",
-    "datashader>=0.19",
+    "datashader>=0.19.1",
     "donfig>=0.8.0",
     "morecantile>=5.4.2",
     "numbagg>=0.9.0",
@@ -61,9 +61,6 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/xpublish_tiles"]
-
-[tool.uv.sources]
-datashader = { git = "https://github.com/holoviz/datashader.git", rev = "2ff83af86022f667015488d2b2d602409b931cf4" }
 
 [project.optional-dependencies]
 healpix = [

--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -236,6 +236,7 @@ def _bounds_from_combined(
     Ylen: int,
     Xlen: int,
     combine: np.ufunc = np.logical_and,
+    seam_mask: np.ndarray | None = None,
 ) -> tuple[list[int], list[int], list[slice]]:
     """Per-slice combine of ``lat_mask`` with the slice's lon_mask, reduced to
     a per-slice bounding box. Returns ``(y_starts, y_stops, x_indexers)``;
@@ -244,6 +245,10 @@ def _bounds_from_combined(
     Set ``combine`` to ``np.logical_and`` for the normal AABB selection,
     or ``np.logical_or`` for the polar-cap cube-edge-seam fallback
     where the intersection is empty but a union AABB over both candidate sets is desired.
+
+    ``seam_mask`` (polar-cap only) flags cells whose naive lon AABB is
+    meaningless because they straddle the 0/360 seam; such cells are OR'd into
+    the per-slice lon_mask so they always pass the longitude test.
     """
     y_starts: list[int] = []
     y_stops: list[int] = []
@@ -252,6 +257,8 @@ def _bounds_from_combined(
     for sl in lon_slices:
         mask |= x_min <= sl.stop
         mask &= x_max >= sl.start
+        if seam_mask is not None:
+            mask |= seam_mask
         combine(mask, lat_mask, out=mask)
         if mask.any():
             y_s, y_e = _bounds_from_mask(mask, axis=xaxis, size=Ylen)
@@ -812,6 +819,7 @@ class CurvilinearCellIndex(xr.Index):
     cell_x_max: np.ndarray
     cell_y_min: np.ndarray
     cell_y_max: np.ndarray
+    cell_crosses_seam: np.ndarray
     _dXmin: float
     _dYmin: float
     tripolar_fold_row: int | None
@@ -906,6 +914,15 @@ class CurvilinearCellIndex(xr.Index):
         self.cell_x_min, self.cell_x_max = _cell_min_max(
             self.corner_x, xaxis=xaxis, yaxis=yaxis
         )
+        # Cells whose 4 corners straddle the 0/360 (or ±180) longitude seam have
+        # a naive (min, max) AABB spanning the *complementary* arc, so the
+        # standard interval-overlap test wrongly excludes them. Flag them so
+        # polar-cap `.sel` can treat them as matching any longitude: they wind
+        # around the pole and genuinely span a wide lon range, and the
+        # over-selection is clipped to the canvas at render time. Non-polar-cap
+        # grids have unwrapped, monotonic lons (see `Curvilinear.from_dataset`),
+        # so the span never exceeds 180° and this mask is all-False there.
+        self.cell_crosses_seam = (self.cell_x_max - self.cell_x_min) > 180.0
         # 1D per-row lat aggregates used by `.sel` to find the row-bbox of a
         # query without materializing the full 2D ``lat_mask``: for a small
         # bbox this collapses ~15M-element work into a 1D scan of ~Ylen
@@ -943,7 +960,7 @@ class CurvilinearCellIndex(xr.Index):
         else:
             lat_row_start = int(row_nonzero[0])
             lat_row_stop = int(row_nonzero[-1]) + 1
-        lat_mask, x_min, x_max = self._lat_mask_for_rows(
+        lat_mask, x_min, x_max, seam_mask = self._lat_mask_for_rows(
             slice(lat_row_start, lat_row_stop), bbox=bbox
         )
 
@@ -976,6 +993,7 @@ class CurvilinearCellIndex(xr.Index):
             yaxis=yaxis,
             Ylen=lat_row_stop - lat_row_start,
             Xlen=Xlen,
+            seam_mask=seam_mask if self.is_polar_cap else None,
         )
         if x_indexers:
             y_start = min(y_starts) + lat_row_start
@@ -992,8 +1010,8 @@ class CurvilinearCellIndex(xr.Index):
                 # This is a rare case caught by property testing. There is a unit test now for
                 # Tile(x=30948, y=0, z=16). Again a more principled solution would be to transform
                 # to the face-local coordinate system
-                full_lat_mask, full_x_min, full_x_max = self._lat_mask_for_rows(
-                    slice(0, Ylen), bbox=bbox
+                full_lat_mask, full_x_min, full_x_max, full_seam_mask = (
+                    self._lat_mask_for_rows(slice(0, Ylen), bbox=bbox)
                 )
                 y_starts, y_stops, x_indexers = _bounds_from_combined(
                     lat_mask=full_lat_mask,
@@ -1005,6 +1023,7 @@ class CurvilinearCellIndex(xr.Index):
                     Ylen=Ylen,
                     Xlen=Xlen,
                     combine=np.logical_or,
+                    seam_mask=full_seam_mask,
                 )
                 if x_indexers:
                     y_start = min(y_starts)
@@ -1034,18 +1053,23 @@ class CurvilinearCellIndex(xr.Index):
 
     def _lat_mask_for_rows(
         self, y_slice: slice, *, bbox: BBox
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Slice the cached cell bounds to ``y_slice`` rows and build the per-
         cell lat-overlap mask for ``bbox``. Returns
-        ``(lat_mask, x_min, x_max)`` over those rows for downstream lon-mask
-        combines.
+        ``(lat_mask, x_min, x_max, seam_mask)`` over those rows for downstream
+        lon-mask combines.
         """
         sl: list[slice] = [slice(None), slice(None)]
         sl[self.yaxis] = y_slice
         idx = tuple(sl)
         lat_mask = self.cell_y_min[idx] <= bbox.north
         lat_mask &= self.cell_y_max[idx] >= bbox.south
-        return lat_mask, self.cell_x_min[idx], self.cell_x_max[idx]
+        return (
+            lat_mask,
+            self.cell_x_min[idx],
+            self.cell_x_max[idx],
+            self.cell_crosses_seam[idx],
+        )
 
     def equals(self, other: xr.Index, **kwargs: Any) -> bool:
         if not isinstance(other, CurvilinearCellIndex):

--- a/uv.lock
+++ b/uv.lock
@@ -1183,8 +1183,8 @@ wheels = [
 
 [[package]]
 name = "datashader"
-version = "0.19.0.post1.dev6+g2ff83af86"
-source = { git = "https://github.com/holoviz/datashader.git?rev=2ff83af86022f667015488d2b2d602409b931cf4#2ff83af86022f667015488d2b2d602409b931cf4" }
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorcet" },
     { name = "multipledispatch" },
@@ -1198,6 +1198,10 @@ dependencies = [
     { name = "scipy" },
     { name = "toolz" },
     { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/4b/a9141f286f0c01685e9715ba3404769a6138e74575c4d5ccbaa95a22c3bd/datashader-0.19.1.tar.gz", hash = "sha256:f62d880a4a431813f9bb3959e565feda79c1634f889aaadcf948cb0d0c114cdd", size = 10581968, upload-time = "2026-05-19T07:53:06.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/41/247627c8b9fef5c605d00546b85771a8fe42975b9616a557cead5468789b/datashader-0.19.1-py3-none-any.whl", hash = "sha256:7ce7154ff3ed070607f429355f57002fee5a17964e47c0b6447eeafe8cef9c82", size = 10715897, upload-time = "2026-05-19T07:53:03.431Z" },
 ]
 
 [[package]]
@@ -5168,7 +5172,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.5.2" },
     { name = "cf-xarray", specifier = ">=0.11.1" },
     { name = "cftime", specifier = ">=1.6.4.post1" },
-    { name = "datashader", git = "https://github.com/holoviz/datashader.git?rev=2ff83af86022f667015488d2b2d602409b931cf4" },
+    { name = "datashader", specifier = ">=0.19.1" },
     { name = "donfig", specifier = ">=0.8.0" },
     { name = "fastapi" },
     { name = "healpix-geo", marker = "extra == 'complete'", specifier = ">=0.0.10" },


### PR DESCRIPTION
## Problem

`test_property_global_render_no_transparent_tile` fails on the cubed-sphere dataset for near-pole tiles (e.g. `Tile(x=31, y=0, z=5)` in WorldCRS84Quad): ~41% of the tile renders transparent.

## Root cause

`CurvilinearCellIndex` caches per-cell longitude bounds as a naive `min/max` over the 4 corner lons. A polar-cap cell whose corners straddle the 0°/360° seam (e.g. `{16.5°, 35°, 350°, 350°}`) gets the AABB `[16.5°, 350°]` — the *complementary* arc. The interval-overlap test in `.sel` then excludes it, so the wedge of cells covering ~84.4–85.6°N at lon≈0 is dropped, leaving a transparent band.

The existing polar-cap seam fallback only fires when *nothing* matched (`if not x_indexers`). Here the central pole cells match, masking the dropped seam cells.

This is **not** a datashader bug — output is byte-identical across the datashader-0.19.1 boundary.

## Fix

Flag cells whose corner lon span exceeds 180° (`cell_crosses_seam`) and OR them into the longitude mask for polar-cap selection, so they always pass the lon test (latitude still filters them). Such cells genuinely wind around the pole and span a wide lon range, so this is correct, not merely conservative; any over-selection is clipped to the canvas. Non-polar-cap grids have unwrapped monotonic lons, so the mask is all-`False` and their behavior is unchanged.

Also bumps datashader from the `fix_polygons` PR-branch git pin to the released `>=0.19.1` (holoviz/datashader#1495 is now merged) — orthogonal cleanup.

## Verification

- Failing tile `(31, 0, z5)`: 40.99% → 0.0% transparent
- `test_property_global_render_no_transparent_tile` passes
- 47 grids/pipeline tests pass, incl. the `x=30948` seam-fallback unit test and 22 snapshots
- `ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)