### PR TITLE
Fix CRS schema generation

### DIFF
--- a/src/xpublish_tiles/xpublish/wms/types.py
+++ b/src/xpublish_tiles/xpublish/wms/types.py
@@ -1,11 +1,13 @@
-from typing import Any, Literal, Union, overload
+from typing import Annotated, Any, Literal, Union, overload
 
 from pydantic import (
     AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
+    PlainSerializer,
     RootModel,
+    WithJsonSchema,
     field_validator,
     model_validator,
 )
@@ -23,6 +25,18 @@ from xpublish_tiles.validators import (
     validate_range_color,
     validate_style,
 )
+
+
+def _serialize_crs(crs: CRS) -> str:
+    authority = crs.to_authority()
+    return ":".join(authority) if authority else crs.to_wkt()
+
+
+CRSQueryParam = Annotated[
+    CRS,
+    PlainSerializer(_serialize_crs, return_type=str),
+    WithJsonSchema({"type": "string", "examples": ["EPSG:4326"]}),
+]
 
 
 class WMSBaseQuery(BaseModel):
@@ -54,8 +68,9 @@ class WMSGetMapQuery(WMSBaseQuery):
         ("raster", "default"),
         description="Style to use for the query. Defaults to raster/default. Default may be replaced by the name of any colormap available to matplotlibs",
     )
-    crs: CRS = Field(
-        CRS.from_epsg(4326),
+    crs: CRSQueryParam = Field(
+        "EPSG:4326",
+        validate_default=True,
         description="Coordinate reference system to use for the query. Default is EPSG:4326",
     )
     time: str | None = Field(
@@ -178,8 +193,9 @@ class WMSGetFeatureInfoQuery(WMSBaseQuery):
         None,
         description="Optional elevation to get feature info for. Only valid when the layer has an elevation dimension. To get all elevations, use 'all', to get a range of elevations, use 'start/end'",
     )
-    crs: CRS = Field(
-        CRS.from_epsg(4326),
+    crs: CRSQueryParam = Field(
+        "EPSG:4326",
+        validate_default=True,
         description="Coordinate reference system to use for the query. Currently only EPSG:4326 is supported for this request",
     )
     bbox: BBox = Field(

--- a/tests/test_xpublish/test_openapi.py
+++ b/tests/test_xpublish/test_openapi.py
@@ -1,0 +1,40 @@
+import warnings
+
+import pytest
+import xpublish
+from fastapi.testclient import TestClient
+from pydantic.json_schema import PydanticJsonSchemaWarning
+
+from xpublish_tiles.xpublish.tiles import TilesPlugin
+from xpublish_tiles.xpublish.wms import WMSPlugin
+
+
+@pytest.fixture(scope="session")
+def openapi_client(air_dataset):
+    rest = xpublish.Rest(
+        {"air": air_dataset},
+        plugins={"tiles": TilesPlugin(), "wms": WMSPlugin()},
+    )
+    return TestClient(rest.app)
+
+
+def test_openapi_schema_generation(openapi_client):
+    """The full OpenAPI schema must be generatable with all plugins registered.
+
+    Guards against query model fields whose types pydantic cannot render to
+    JSON Schema (e.g. raw pyproj.CRS), which would 500 every /openapi.json
+    and /docs request.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PydanticJsonSchemaWarning)
+        response = openapi_client.get("/openapi.json")
+    assert response.status_code == 200
+
+    schema = response.json()
+    assert any("/wms" in path for path in schema["paths"])
+    assert any("/tiles" in path for path in schema["paths"])
+
+    for model in ("WMSGetMapQuery", "WMSGetFeatureInfoQuery"):
+        crs = schema["components"]["schemas"][model]["properties"]["crs"]
+        assert crs["type"] == "string"
+        assert crs["default"] == "EPSG:4326"


### PR DESCRIPTION
When adding Tiles to an existing Xpublish server, /docs was erroring due to an issue with generating the OpenAPI schema due to CRS being directly imported from pyproj.

This makes CRS an annotated field so that Pydantic can work with it and the OpenAPI schema can be generated.

I also added a test to check that the OpenAPI schema can be generated.