### PR TITLE
fix: treat numba's omp threading layer as safe for concurrent rendering

### DIFF
--- a/src/xpublish_tiles/utils.py
+++ b/src/xpublish_tiles/utils.py
@@ -10,9 +10,36 @@ import cf_xarray  # noqa: F401
 import xarray as xr
 from xpublish_tiles.logger import log_duration, logger
 
-# Only use lock if tbb is not available
 HAS_TBB = importlib.util.find_spec("tbb") is not None
-NUMBA_THREADING_LOCK = contextlib.nullcontext() if HAS_TBB else threading.Lock()
+
+
+def _has_threadsafe_numba_layer() -> bool:
+    """Whether numba will select a threading layer that is safe for concurrent
+    entry into parallel regions from multiple Python threads.
+
+    tbb and omp are threadsafe; the workqueue fallback is not, so without one
+    of the safe layers we serialize numba sections with a lock instead.
+    https://numba.readthedocs.io/en/stable/user/threading-layer.html
+    """
+    from numba import config as numba_config
+
+    forced = numba_config.THREADING_LAYER
+    if forced in ("tbb", "omp", "safe", "threadsafe"):
+        return True
+    if forced != "default":
+        return False
+    if HAS_TBB:
+        return True
+    try:
+        from numba.np.ufunc import omppool  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+NUMBA_THREADING_LOCK = (
+    contextlib.nullcontext() if _has_threadsafe_numba_layer() else threading.Lock()
+)
 
 
 def xarray_object_key(

--- a/src/xpublish_tiles/utils.py
+++ b/src/xpublish_tiles/utils.py
@@ -10,8 +10,6 @@ import cf_xarray  # noqa: F401
 import xarray as xr
 from xpublish_tiles.logger import log_duration, logger
 
-HAS_TBB = importlib.util.find_spec("tbb") is not None
-
 
 def _has_threadsafe_numba_layer() -> bool:
     """Whether numba will select a threading layer that is safe for concurrent
@@ -28,7 +26,7 @@ def _has_threadsafe_numba_layer() -> bool:
         return True
     if forced != "default":
         return False
-    if HAS_TBB:
+    if importlib.util.find_spec("tbb") is not None:
         return True
     try:
         # must actually import (not find_spec): on macOS the omppool extension

--- a/src/xpublish_tiles/utils.py
+++ b/src/xpublish_tiles/utils.py
@@ -23,7 +23,7 @@ def _has_threadsafe_numba_layer() -> bool:
     """
     from numba import config as numba_config
 
-    forced = numba_config.THREADING_LAYER
+    forced = getattr(numba_config, "THREADING_LAYER", "default")
     if forced in ("tbb", "omp", "safe", "threadsafe"):
         return True
     if forced != "default":
@@ -31,7 +31,10 @@ def _has_threadsafe_numba_layer() -> bool:
     if HAS_TBB:
         return True
     try:
-        from numba.np.ufunc import omppool  # noqa: F401
+        # must actually import (not find_spec): on macOS the omppool extension
+        # exists but fails to dlopen because the numba wheel lacks a usable
+        # libomp rpath (https://github.com/numba/numba/issues/10492)
+        importlib.import_module("numba.np.ufunc.omppool")
     except ImportError:
         return False
     return True


### PR DESCRIPTION
The numba serialization lock was keyed on tbb package presence only. After #260, tbb never installs on arm64 linux — where numba auto-selects the omp layer, which is just as threadsafe — but the lock still engaged and serialized all concurrent renders. This inspects the configured threading layer and available pools instead, keeping the lock only for the non-threadsafe workqueue fallback.

Verified by serving tiles from the booth arm64 image and checking the lock under each config:

| environment | layer | lock |
|---|---|---|
| arm64 linux, default | omp | none (was: lock) |
| `NUMBA_THREADING_LAYER=workqueue` | workqueue | lock |
| macOS, default | workqueue | lock (unchanged) |
| macOS + brew libomp + `DYLD_FALLBACK_LIBRARY_PATH` | omp | none |

Concurrent tile responses are byte-identical to the locked baseline. macOS stays locked by default because the PyPI numba wheel's omppool can't load (numba/numba#10492 — its only rpath is numba's CI machine); the fix catches that ImportError and falls back.

One caveat: GNU OpenMP isn't fork-safe, so forking consumers should force `NUMBA_THREADING_LAYER=workqueue` to get the lock back. Booth doesn't fork.

[This is Claude Code on behalf of Samantha Hughes]

🤖 Generated with [Claude Code](https://claude.com/claude-code)