### PR TITLE
Don't emit scientific notation in tilejson URLs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
         if: matrix.shard == 1
         run: uv run ty check src/ tests/
 
+      - name: Run doctests
+        if: matrix.shard == 1
+        run: uv run pytest --doctest-modules src/xpublish_tiles --ignore=src/xpublish_tiles/testing
+
       # To debug snapshot test failures run with --debug-visual-save and download the artifact zip created in the next step.
       - name: Run tests with coverage
         env:

--- a/src/xpublish_tiles/utils.py
+++ b/src/xpublish_tiles/utils.py
@@ -6,6 +6,7 @@ import time
 from typing import Any
 
 import cf_xarray  # noqa: F401
+import numpy as np
 
 import xarray as xr
 from xpublish_tiles.logger import log_duration, logger
@@ -153,6 +154,27 @@ def normalize_tilejson_bounds(
         w, e = -180.0, 180.0
 
     return [w, float(south), e, float(north)]
+
+
+def format_number_for_url(value: float) -> str:
+    """Format a number for inclusion in a URL query string.
+
+    ``%g`` is unusable here: it emits scientific notation whose ``+`` exponent
+    sign is decoded as a space by query string parsers (``1e+06`` -> ``1e 06``),
+    and it silently rounds to 6 significant digits.
+
+    Examples
+    --------
+    >>> [format_number_for_url(v) for v in (0.0, -3.0, 1.5)]
+    ['0', '-3', '1.5']
+    >>> [format_number_for_url(v) for v in (1e6, -1e6, 1234567.5, 1e21, 1e-7)]
+    ['1000000', '-1000000', '1234567.5', '1000000000000000000000', '0.0000001']
+    >>> [format_number_for_url(v) for v in (float("nan"), float("inf"))]
+    ['nan', 'inf']
+    """
+    if not np.isfinite(value):
+        return str(float(value))
+    return np.format_float_positional(value, trim="-")
 
 
 @contextlib.contextmanager

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -42,7 +42,7 @@ from xpublish_tiles.multiscale import (
 from xpublish_tiles.pipeline import _infer_datatype, pipeline
 from xpublish_tiles.tiles_lib import get_min_zoom
 from xpublish_tiles.types import ImageFormat, LegendFormat, QueryParams
-from xpublish_tiles.utils import normalize_tilejson_bounds
+from xpublish_tiles.utils import format_number_for_url, normalize_tilejson_bounds
 from xpublish_tiles.xpublish.tiles.metadata import (
     create_tileset_for_tms,
     create_tileset_metadata,
@@ -410,11 +410,17 @@ class TilesPlugin(Plugin):
             style = query.style[0] if query.style else "raster"
             variant = query.style[1] if query.style else "default"
 
+            colorscalerange = (
+                ",".join(map(format_number_for_url, query.colorscalerange))
+                if query.colorscalerange
+                else None
+            )
+
             # XYZ template
             url_template = f"{base_url}{tiles_path}/{{z}}/{{y}}/{{x}}?variables={','.join(query.variables)}&style={style}/{variant}&width={query.width}&height={query.height}&f={query.f}&render_errors={str(query.render_errors).lower()}"
             # Append optional color scale range
-            if query.colorscalerange:
-                url_template = f"{url_template}&colorscalerange={query.colorscalerange[0]:g},{query.colorscalerange[1]:g}"
+            if colorscalerange:
+                url_template = f"{url_template}&colorscalerange={colorscalerange}"
 
             if query.colormap:
                 url_template = (
@@ -433,7 +439,7 @@ class TilesPlugin(Plugin):
 
             # Append selectors
             if selectors:
-                selector_qs = "&".join(f"{k}={v}" for k, v in selectors.items())
+                selector_qs = "&".join(f"{k}={quote(v)}" for k, v in selectors.items())
                 url_template = f"{url_template}&{selector_qs}"
 
             # Build legend URL (sibling of tilejson.json)
@@ -442,8 +448,8 @@ class TilesPlugin(Plugin):
                 f"{base_url}{dataset_path}/legend?variables={','.join(query.variables)}"
                 f"&style={style}/{variant}"
             )
-            if query.colorscalerange:
-                legend_url = f"{legend_url}&colorscalerange={query.colorscalerange[0]:g},{query.colorscalerange[1]:g}"
+            if colorscalerange:
+                legend_url = f"{legend_url}&colorscalerange={colorscalerange}"
             if query.colormap:
                 legend_url = f"{legend_url}&colormap={quote(json.dumps(query.colormap))}"
             if query.belowmincolor:

--- a/tests/test_xpublish/test_tiles/test_tiles_plugin.py
+++ b/tests/test_xpublish/test_tiles/test_tiles_plugin.py
@@ -774,6 +774,30 @@ def test_tilejson_endpoint():
     assert "belowmincolor=transparent" in legend_url
     assert "abovemaxcolor=%23ff0000" in legend_url
 
+    # Large/high-precision colorscalerange must not be serialized in scientific
+    # notation: the '+' of the exponent decodes back as a space, and %g would
+    # also round away significant digits.
+    response = client.get(
+        "/datasets/temp/tiles/WebMercatorQuad/tilejson.json",
+        params={
+            "variables": "temperature",
+            "width": 256,
+            "height": 256,
+            "colorscalerange": "0,1234567.5",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    tile_url = body["tiles"][0]
+    assert "colorscalerange=0,1234567.5" in tile_url
+    assert "colorscalerange=0,1234567.5" in body["legend"]
+
+    # The advertised template must be usable as-is
+    tile_response = client.get(
+        tile_url.replace("{z}", "0").replace("{y}", "0").replace("{x}", "0")
+    )
+    assert tile_response.status_code == 200, tile_response.text
+
 
 @pytest.fixture(scope="module")
 def legend_dataset():


### PR DESCRIPTION
Fixes the tiles-view error popup reported in earth-mover/arraylake#7017. The bad
value came from us, not the app.

`get_dataset_tilejson` formatted `colorscalerange` with `%g` when building the
advertised tile and legend URLs. Two bugs from that one format spec:

1. `1000000` → `1e+06`. The `+` in a query string decodes as a space, so the
   template we advertise comes back to us as `colorscalerange=1e 06` and our own
   validator rejects it with a 422. The popup was our own URL failing.
2. `%g` rounds to 6 significant digits, so `0,1234567.5` would round-trip as
   `1.23457e+06` — a quietly different color scale even without the `+` issue.

`format_number_for_url` (in `utils.py`) formats via `np.format_float_positional`:
no exponent, no rounding. Selector values are now percent-encoded too, so a
`valid_time` carrying a `+00:00` offset survives the round trip.

## Tests

- Doctest on `format_number_for_url`.
- A case in `test_tilejson_endpoint` asserting `colorscalerange=0,1234567.5`
  appears in the template *and* that fetching the advertised URL returns 200.
- CI wasn't running doctests at all (`pytest tests`, and `testpaths` excludes
  `src`), so this adds a shard-1 step. The `--ignore` is required:
  `testing/grids/extract_n320.py` imports `bs4`, which isn't a dev dependency.

Note `test_tilejson_endpoint_snapshot` passes no styling params, so none of the
11 metadata snapshots covered this path or change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)