### PR TITLE
Don't detect bathymetry as a Z coordinate

### DIFF
--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -3764,17 +3764,38 @@ def _guess_grid_for_dataset(ds: xr.Dataset) -> GridSystem:
     return primary_grid
 
 
-def _guess_z_dimension(da: xr.DataArray) -> str | None:
+#: Domain geometry, not vertical coordinates. cf-xarray flags them ``vertical``
+#: because a ``positive`` attr alone meets its criteria (FVCOM/ROMS ``h``).
+NOT_VERTICAL_COORDINATE_STANDARD_NAMES = frozenset(
+    {
+        "sea_floor_depth_below_geoid",
+        "sea_floor_depth_below_mean_sea_level",
+        "sea_floor_depth_below_reference_ellipsoid",
+        "sea_floor_depth_below_sea_surface",
+        "sea_surface_height_above_geoid",
+        "sea_surface_height_above_mean_sea_level",
+        "sea_surface_height_above_reference_ellipsoid",
+        "surface_altitude",
+        "water_surface_height_above_reference_datum",
+    }
+)
+
+
+def _guess_z_dimension(da: xr.DataArray, *, exclude_dims: set[str]) -> str | None:
     # Returns the name of a Z coordinate variable on ``da`` whose underlying
     # dimension is in ``da.dims``. The coordinate may itself be a dim coord
     # (e.g. ``depth`` on dim ``depth``) or a 1D non-dim coord (e.g. ``deptht``
     # on dim ``k``).
+    # ``exclude_dims``: the horizontal grid dims. A Z coord never lives on one;
+    # this rejects bathymetry that has no standard_name.
     possible = set(da.cf.coordinates.get("vertical", {})) | set(da.cf.axes.get("Z", {}))
     for z in sorted(possible):
         if z not in da.coords:
             continue
         zda = da.coords[z]
-        if zda.ndim == 1 and zda.dims[0] in da.dims:
+        if zda.attrs.get("standard_name") in NOT_VERTICAL_COORDINATE_STANDARD_NAMES:
+            continue
+        if zda.ndim == 1 and zda.dims[0] in da.dims and zda.dims[0] not in exclude_dims:
             return z
     return None
 
@@ -3939,8 +3960,9 @@ def _detect_grid_system(ds: xr.Dataset, name: Hashable) -> GridSystem:
         grid = CubedSphere.from_dataset(
             ds, meta.crs, meta.X, meta.Y, face_dim=meta.face_dim
         )
-        grid.Z = _guess_z_dimension(ds[name])
-        _validate_grid_dims(grid, ds[name])
+        var = cf_get(ds, name)
+        grid.Z = _guess_z_dimension(var, exclude_dims=grid.dims_for(var))
+        _validate_grid_dims(grid, var)
         return grid
 
     try:
@@ -3963,8 +3985,9 @@ def _detect_grid_system(ds: xr.Dataset, name: Hashable) -> GridSystem:
     # actually apply to ``name`` (e.g. an auxiliary var like ``contacts``
     # on a cubed-sphere dataset shares the ``face_dim`` but lacks the
     # 2D lat/lon dims). Reject these so per-variable callers can skip them.
-    grid.Z = _guess_z_dimension(cf_get(ds, name))
-    _validate_grid_dims(grid, ds[name])
+    var = cf_get(ds, name)
+    grid.Z = _guess_z_dimension(var, exclude_dims=grid.dims_for(var))
+    _validate_grid_dims(grid, var)
     return grid
 
 

--- a/src/xpublish_tiles/pipeline.py
+++ b/src/xpublish_tiles/pipeline.py
@@ -46,6 +46,7 @@ from xpublish_tiles.lib import (
     anynotfinite,
     apply_default_pad,
     async_run,
+    cf_get,
     coarsen_mean_pad,
     decompressed_size_bytes,
     get_data_load_semaphore,
@@ -1080,7 +1081,8 @@ def apply_query(
             ) from None
 
         grid = guess_grid_system(ds, name)
-        array = ds[name]
+        # Read as detection did, so a Z that only `cf_get` promotes is selectable.
+        array = cf_get(ds, name)
         if grid.Z is not None and grid.Z in array.coords:
             # This code assumes all datasets are ocean datasets :/
             if grid.Z not in array.xindexes:

--- a/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
+++ b/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
@@ -14,7 +14,7 @@ import pyproj.aoi
 
 import xarray as xr
 from xpublish_tiles.grids import GridSystem, guess_grid_system
-from xpublish_tiles.lib import async_run, timedelta_to_iso8601
+from xpublish_tiles.lib import async_run, cf_get, timedelta_to_iso8601
 from xpublish_tiles.tiles_lib import get_min_zoom
 from xpublish_tiles.types import OutputBBox, OutputCRS
 from xpublish_tiles.xpublish.tiles.types import (
@@ -250,7 +250,8 @@ async def extract_dimension_extents(
     dimensions = []
 
     grid = await async_run(guess_grid_system, ds, name, cf_coords=cf_coords)
-    data_array = ds[name]
+    # Read as detection did, so a Z that only `cf_get` promotes reports as VERTICAL.
+    data_array = cf_get(ds, name)
 
     # Grid-owned dims (X, Y, and faceted ``face_dim``) are skipped for
     # custom dimension extents — they're an implementation detail of the grid.

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,3 +1,4 @@
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Literal, cast
 from unittest.mock import patch
@@ -38,6 +39,7 @@ from xpublish_tiles.grids import (
     Triangular,
     UgridIndexer,
     _guess_grid_for_dataset,
+    _guess_z_dimension,
     _resolve_corner_name,
     find_cubed_sphere_face_dim,
     guess_coordinate_vars,
@@ -58,6 +60,7 @@ from xpublish_tiles.lib import (
     normalize_slicers,
 )
 from xpublish_tiles.pipeline import (
+    apply_query,
     apply_slicers,
     fix_coordinate_discontinuities,
     load_plans,
@@ -96,6 +99,8 @@ from xpublish_tiles.testing.tiles import TILES
 from xpublish_tiles.tiles_lib import get_max_zoom, get_min_zoom
 from xpublish_tiles.types import ContinuousData
 from xpublish_tiles.ugrid import detect_mesh, load_connectivity
+from xpublish_tiles.xpublish.tiles.tile_matrix import extract_dimension_extents
+from xpublish_tiles.xpublish.tiles.types import DimensionType
 
 TRIANGULAR_SENTINEL = 1
 HEALPIX_SENTINEL = 2
@@ -443,11 +448,6 @@ def test_z_coord_with_mismatched_dim_name():
     should assign a default index and select on it, and the dimension extent
     metadata should report ``deptht`` (not the bare dim ``k``).
     """
-    import asyncio
-
-    from xpublish_tiles.pipeline import apply_query
-    from xpublish_tiles.xpublish.tiles.tile_matrix import extract_dimension_extents
-
     nz, ny, nx = 5, 3, 4
     ds = xr.Dataset(
         {
@@ -541,18 +541,24 @@ def test_grid_detection_duplicate_standard_name():
 
 def test_cf_get_attaches_aux_vertical_coordinate():
     """cf_get must promote an auxiliary Z coordinate referenced only via the
-    variable's ``coordinates`` attribute, mirroring scalar ``ds.cf[name]``."""
+    variable's ``coordinates`` attribute, mirroring scalar ``ds.cf[name]``.
+
+    ``apply_query`` and the dimension-extent metadata must read the variable
+    back the same way, otherwise that Z is invisible to them: selection falls
+    through to ``isel(-1)`` on the level dim, and the extent reports the bare
+    dim as CUSTOM instead of the coord as VERTICAL.
+    """
     nz, ny, nx = 4, 3, 5
     ds = xr.Dataset(
         {
             "foo": (
                 ("k", "lat", "lon"),
-                np.zeros((nz, ny, nx)),
+                np.arange(nz * ny * nx, dtype="float64").reshape(nz, ny, nx),
                 {"coordinates": "depth_aux"},
             ),
             "depth_aux": (
                 ("k",),
-                np.arange(nz, dtype="float64"),
+                np.arange(nz, dtype="float64") * 10.0,
                 {"standard_name": "depth", "positive": "down", "units": "m"},
             ),
         },
@@ -573,10 +579,84 @@ def test_cf_get_attaches_aux_vertical_coordinate():
 
     da = cf_get(ds, "foo")
     assert "depth_aux" in da.coords
-    npt.assert_allclose(da["depth_aux"].values, np.arange(nz, dtype="float64"))
+    npt.assert_allclose(da["depth_aux"].values, np.arange(nz, dtype="float64") * 10.0)
 
     grid = guess_grid_system(ds, "foo")
     assert grid.Z == "depth_aux"
+
+    selected = apply_query(ds, variables=["foo"], selectors={})["foo"].da
+    assert "k" not in selected.dims
+    npt.assert_allclose(selected["depth_aux"].values, 0.0)
+    npt.assert_allclose(selected.values, ds["foo"].isel(k=0).values)
+
+    extents = asyncio.run(extract_dimension_extents(ds, "foo"))
+    assert [(e.name, e.type) for e in extents] == [("depth_aux", DimensionType.VERTICAL)]
+
+
+@pytest.mark.parametrize(
+    "h_attrs",
+    [
+        pytest.param(
+            {
+                "standard_name": "sea_floor_depth_below_geoid",
+                "positive": "down",
+                "units": "m",
+                "long_name": "Bathymetry",
+            },
+            id="standard_name",
+        ),
+        pytest.param(
+            {"positive": "down", "units": "m", "long_name": "Bathymetry"},
+            id="no_standard_name",
+        ),
+    ],
+)
+def test_bathymetry_is_not_a_z_coordinate(h_attrs):
+    """Bathymetry is a field over the grid, not a vertical coordinate.
+
+    FVCOM datasets (e.g. NGOFS2) carry ``h`` as a 1D coordinate on the mesh
+    ``node`` dim. cf-xarray reports it as ``vertical`` because of its
+    ``positive`` attr, but nothing is a function of bathymetry — and its values
+    aren't unique, so ``sel(h=0, method='nearest')`` raises.
+
+    Excluded by ``standard_name`` when it has one, and by the horizontal-dim
+    check when it doesn't.
+    """
+    n = 8
+    rng = np.random.default_rng(0)
+    ds = xr.Dataset(
+        {"salinity_surface": (("time", "node"), np.zeros((2, n)))},
+        coords={
+            "h": (("node",), np.repeat([1.0, 2.0, 3.0, 4.0], 2), h_attrs),
+            "lon": (
+                ("node",),
+                rng.uniform(-97, -85, n),
+                {"standard_name": "longitude", "units": "degrees_east"},
+            ),
+            "lat": (
+                ("node",),
+                rng.uniform(22, 30, n),
+                {"standard_name": "latitude", "units": "degrees_north"},
+            ),
+            "time": (("time",), pd.date_range("2024-01-01", periods=2)),
+        },
+    )
+
+    assert "h" in ds["salinity_surface"].cf.coordinates["vertical"]
+
+    grid = guess_grid_system(ds, "salinity_surface")
+    assert grid.Z is None
+
+    validated = apply_query(ds, variables=["salinity_surface"], selectors={})
+    da = validated["salinity_surface"].da
+    assert da.sizes["node"] == n
+
+    # Which mechanism caught it: standard_name on its own, else the
+    # horizontal-dim check.
+    caught_by_standard_name = "standard_name" in h_attrs
+    assert _guess_z_dimension(ds["salinity_surface"], exclude_dims=set()) == (
+        None if caught_by_standard_name else "h"
+    )
 
 
 def test_polar_grid_from_dataset_missing_location():


### PR DESCRIPTION
Fixes a 422 on NGOFS2 `salinity_surface`.

## Bathymetry detected as Z
FVCOM/ROMS `h` has `positive: down`. That attribute alone satisfies cf-xarray's vertical criteria, so `grid.Z = "h"` and `sel(h=0)` raised `InvalidIndexError`.

Two guards in `_guess_z_dimension`:
- Reject `standard_name` in the sea-floor-depth / sea-surface-height / surface-altitude families.
- Reject a candidate whose dim is a horizontal grid dim. Catches bathymetry with no `standard_name`.

## Detection and selection read the variable differently
Detection used `cf_get`, which promotes coords named in the `coordinates` attr. `apply_query`, `extract_dimension_extents` and the CubedSphere detection branch read `ds[name]`. A Z visible only through `cf_get` was skipped: the bottom level was served, and the extent reported `CUSTOM` instead of `VERTICAL`. Only reached with `decode_coords=False` or in-memory datasets. All three now read via `cf_get`.

## Tests
- `test_bathymetry_is_not_a_z_coordinate`, parametrized with and without `standard_name`, asserts which guard fires.
- `test_cf_get_attaches_aux_vertical_coordinate` extended: `apply_query` selects depth 0 and keeps the coord; extent is `VERTICAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)