### PR TITLE
fix: pick the nearest overview level instead of the finest one that covers the tile

### DIFF
--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -160,18 +160,13 @@ def get_resolution_level(
     data_crs = get_crs(levels[0].dataset)
     tile_pixel_size = tms.matrix(zoom).cellSize
 
-    # Iterate coarsest-first and require a strictly smaller distance (beyond
-    # float noise) to switch to a finer level, so exact midpoints resolve coarse.
-    selected = levels[-1]
-    best_distance = math.inf
-    for level in reversed(levels):
+    def _distance(level: ResolutionLevel) -> float:
         pixel_size_tms = _pixel_size_in_tms_units(level.pixel_size, data_crs, tms)
-        distance = abs(math.log(pixel_size_tms / tile_pixel_size))
-        if distance < best_distance - 1e-9:
-            best_distance = distance
-            selected = level
+        # quantize so float noise can't flip an exact tie to a finer level
+        return round(abs(math.log(pixel_size_tms / tile_pixel_size)), 9)
 
-    return selected
+    # min keeps the first of equal keys; coarsest-first makes ties resolve coarse
+    return min(reversed(levels), key=_distance)
 
 
 def assign_leaf_xpublish_ids(tree: DataTree) -> None:

--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 
 import morecantile
@@ -136,9 +137,11 @@ def get_resolution_level(
     """Get the appropriate resolution level from a DataTree.
 
     Behavior:
-    - If zoom + tms provided: Select best resolution level for that zoom
-      by comparing each level's pixel size to the tile's pixel size.
-      Selects the coarsest level that is still finer than the tile.
+    - If zoom + tms provided: Select the level whose pixel size is nearest
+      the tile's pixel size in log space, so the crossover between adjacent
+      levels sits at the geometric mean of their pixel sizes. Ties break
+      toward the coarser level: oversampling costs far more (bytes read +
+      decode) than the slight blur of upsampling.
     - If no zoom: Return finest (highest resolution) level available
     - If no valid levels found: Return None
 
@@ -157,16 +160,16 @@ def get_resolution_level(
     data_crs = get_crs(levels[0].dataset)
     tile_pixel_size = tms.matrix(zoom).cellSize
 
-    # Levels are sorted finest (smallest pixel) to coarsest (largest pixel)
-    # Default to finest level (for when all are coarser than tile - need upscaling)
-    selected = levels[0]
-
-    # Iterate from coarsest to finest, find coarsest level still finer than tile
+    # Iterate coarsest-first and require a strictly smaller distance (beyond
+    # float noise) to switch to a finer level, so exact midpoints resolve coarse.
+    selected = levels[-1]
+    best_distance = math.inf
     for level in reversed(levels):
         pixel_size_tms = _pixel_size_in_tms_units(level.pixel_size, data_crs, tms)
-        if pixel_size_tms <= tile_pixel_size:
+        distance = abs(math.log(pixel_size_tms / tile_pixel_size))
+        if distance < best_distance - 1e-9:
+            best_distance = distance
             selected = level
-            break
 
     return selected
 
@@ -197,9 +200,9 @@ def get_dataset(
     """Extract the appropriate Dataset from a DataTree.
 
     Behavior:
-    - If zoom + tms provided: Select best resolution level for that zoom
-      by comparing each level's pixel size to the tile's pixel size.
-      Selects the coarsest level that is still finer than the tile.
+    - If zoom + tms provided: Select the level whose pixel size is nearest
+      the tile's pixel size in log space (ties toward coarser); see
+      ``get_resolution_level``.
     - If no zoom: Return finest (highest resolution) level available
     - If no valid levels found: Try root dataset, else raise ValueError
     """

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -122,6 +122,67 @@ def test_get_resolution_level_returns_none_on_empty_tree(tms):
     assert level is None
 
 
+def _pyramid_tree(*pixel_sizes: float) -> DataTree:
+    return DataTree.from_dict(
+        {
+            str(i): xr.Dataset(
+                {"data": (("y", "x"), [[1, 2], [3, 4]])},
+                attrs={
+                    "spatial:transform": [pixel_size, 0, 0, 0, -pixel_size, 0],
+                    "proj:code": "EPSG:4326",
+                },
+            )
+            for i, pixel_size in enumerate(pixel_sizes)
+        }
+    )
+
+
+@pytest.fixture
+def wgs84_tms():
+    return morecantile.tms.get("WGS1984Quad")
+
+
+def test_get_resolution_level_picks_nearest_in_log_space(wgs84_tms):
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+
+    # Tile pixel just inside the geometric mean of a 4x pyramid: finer wins
+    tree = _pyramid_tree(tile_pixel_size / 1.9, tile_pixel_size * 4 / 1.9)
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size / 1.9
+
+    # Just past the geometric mean: coarser wins, even though it is
+    # coarser than the tile (bounded upsampling instead of 16x the data)
+    tree = _pyramid_tree(tile_pixel_size / 2.1, tile_pixel_size * 4 / 2.1)
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size * 4 / 2.1
+
+
+def test_get_resolution_level_tie_prefers_coarser(wgs84_tms):
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+
+    # Exactly at the geometric mean (2x finer vs 2x coarser): pick coarser
+    tree = _pyramid_tree(tile_pixel_size / 2, tile_pixel_size * 2)
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size * 2
+
+
+def test_get_resolution_level_4x_pyramid_zoom_transitions(wgs84_tms):
+    # 4x pyramid with native resolution exactly matching zoom 10 tiles:
+    # the 4x overview is exact at zoom 8. Zoom 9 sits at the midpoint and
+    # must use the overview, not native (16x the data for a 2x-fine tile).
+    native = wgs84_tms.matrix(10).cellSize
+    overview = 4 * native
+    tree = _pyramid_tree(native, overview)
+
+    for zoom, expected in [(8, overview), (9, overview), (10, native), (11, native)]:
+        level = get_resolution_level(tree, zoom=zoom, tms=wgs84_tms)
+        assert level is not None
+        assert level.pixel_size == expected, f"zoom {zoom}"
+
+
 def test_get_dataset_geozarr_high_zoom_returns_finest():
     tree = GEOZARR_MULTISCALE.create()
     tms = morecantile.tms.get("WebMercatorQuad")


### PR DESCRIPTION
## Problem
- For a tile at zoom `z`, we picked the coarsest overview that was still finer than the tile (never coarser)
- With a 4x pyramid this means `z=9` snaps all the way to native resolution, reading and decoding ~16x more data than serving it from the same overview `z=8` uses.

## Proposed Solution

This PR updates overview selection by selecting the level whose resolution is closest to the tile's (in ratio terms), so the switch between two levels happens halfway between them. Ties break toward the coarser level: a slightly soft tile is cheap, an oversampled one is 16x the decode work.

This is the same idea as  [GDAL's oversampling threshold](https://github.com/OSGeo/gdal/blob/master/gcore/rasterio.cpp#L4595-L4597), but adaptive instead of fixed so it works the same for 2x, 4x, or irregular pyramids. 

-> `z=9` now renders from the 4x overview (2x upsampled) instead of native.
-> `z=10–11` still uses native, and each tile there decodes whole native chunks to use a small slice of them