### PR TITLE
Add configurable overview selection strategy

### DIFF
--- a/src/xpublish_tiles/config.py
+++ b/src/xpublish_tiles/config.py
@@ -25,6 +25,8 @@ config = donfig.Config(
             "async_load_timeout_per_tile": 20,  # seconds; None to disable
             "num_concurrent_data_loads": 4,  # max concurrent tile data loads; None to disable
             "grid_cache_max_size": 16,  # maximum number of grid systems to cache
+            # one of "nearest", "coarser", "finer"; see OverviewSelectionStrategy
+            "overview_selection_strategy": "nearest",
         }
     ],
     paths=[],

--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -6,7 +6,9 @@ from pyproj import CRS
 
 import xarray as xr
 from xarray import DataTree
+from xpublish_tiles.config import config
 from xpublish_tiles.logger import logger
+from xpublish_tiles.types import OverviewSelectionStrategy
 
 
 @dataclass
@@ -133,15 +135,22 @@ def get_resolution_level(
     *,
     zoom: int | None = None,
     tms: morecantile.TileMatrixSet | None = None,
+    strategy: OverviewSelectionStrategy | None = None,
 ) -> ResolutionLevel | None:
     """Get the appropriate resolution level from a DataTree.
 
     Behavior:
-    - If zoom + tms provided: Select the level whose pixel size is nearest
-      the tile's pixel size in log space, so the crossover between adjacent
-      levels sits at the geometric mean of their pixel sizes. Ties break
-      toward the coarser level: oversampling costs far more (bytes read +
-      decode) than the slight blur of upsampling.
+    - If zoom + tms provided: Select a level according to ``strategy``, which
+      defaults to the ``overview_selection_strategy`` config value.
+      NEAREST picks the level whose pixel size is nearest the tile's pixel
+      size in log space, so the crossover between adjacent levels sits at the
+      geometric mean of their pixel sizes. Ties break toward the coarser
+      level: oversampling costs far more (bytes read + decode) than the
+      slight blur of upsampling.
+      COARSER picks the finest level that is still no finer than the tile,
+      FINER the coarsest level that is still no coarser than the tile. Both
+      fall back to the closest level available when the tile's pixel size
+      falls outside the range of levels.
     - If no zoom: Return finest (highest resolution) level available
     - If no valid levels found: Return None
 
@@ -156,17 +165,34 @@ def get_resolution_level(
     if zoom is None or tms is None:
         return levels[0]
 
+    if strategy is None:
+        strategy = OverviewSelectionStrategy(config.get("overview_selection_strategy"))
+
     # Select best level for the requested zoom
     data_crs = get_crs(levels[0].dataset)
     tile_pixel_size = tms.matrix(zoom).cellSize
 
-    def _distance(level: ResolutionLevel) -> float:
+    def _log_ratio(level: ResolutionLevel) -> float:
         pixel_size_tms = _pixel_size_in_tms_units(level.pixel_size, data_crs, tms)
-        # quantize so float noise can't flip an exact tie to a finer level
-        return round(abs(math.log(pixel_size_tms / tile_pixel_size)), 9)
+        # quantize so float noise can't flip an exact match to the wrong side
+        return round(math.log(pixel_size_tms / tile_pixel_size), 9)
 
-    # min keeps the first of equal keys; coarsest-first makes ties resolve coarse
-    return min(reversed(levels), key=_distance)
+    match strategy:
+        case OverviewSelectionStrategy.NEAREST:
+            # min keeps the first of equal keys; coarsest-first makes ties resolve coarse
+            return min(reversed(levels), key=lambda level: abs(_log_ratio(level)))
+        case OverviewSelectionStrategy.COARSER:
+            # levels are finest-first, so the first non-finer level is the
+            # finest one that is still at least as coarse as the tile
+            return next(
+                (level for level in levels if _log_ratio(level) >= 0),
+                levels[-1],
+            )
+        case OverviewSelectionStrategy.FINER:
+            return next(
+                (level for level in reversed(levels) if _log_ratio(level) <= 0),
+                levels[0],
+            )
 
 
 def assign_leaf_xpublish_ids(tree: DataTree) -> None:
@@ -191,17 +217,17 @@ def get_dataset(
     *,
     zoom: int | None = None,
     tms: morecantile.TileMatrixSet | None = None,
+    strategy: OverviewSelectionStrategy | None = None,
 ) -> xr.Dataset:
     """Extract the appropriate Dataset from a DataTree.
 
     Behavior:
-    - If zoom + tms provided: Select the level whose pixel size is nearest
-      the tile's pixel size in log space (ties toward coarser); see
+    - If zoom + tms provided: Select a level according to ``strategy``; see
       ``get_resolution_level``.
     - If no zoom: Return finest (highest resolution) level available
     - If no valid levels found: Try root dataset, else raise ValueError
     """
-    level = get_resolution_level(tree, zoom=zoom, tms=tms)
+    level = get_resolution_level(tree, zoom=zoom, tms=tms, strategy=strategy)
 
     if level is not None:
         return level.dataset

--- a/src/xpublish_tiles/types.py
+++ b/src/xpublish_tiles/types.py
@@ -41,6 +41,19 @@ class LegendFormat(enum.StrEnum):
     JSON = "json"
 
 
+class OverviewSelectionStrategy(enum.StrEnum):
+    """How to pick a multiscale overview for a requested zoom level.
+
+    NEAREST: the level whose pixel size is nearest the tile's in log space.
+    COARSER: the finest level that is still no finer than the tile.
+    FINER: the coarsest level that is still no coarser than the tile.
+    """
+
+    NEAREST = "nearest"
+    COARSER = "coarser"
+    FINER = "finer"
+
+
 class SelectionMethod(str, enum.Enum):
     """Selection methods for dimension indexing.
 

--- a/src/xpublish_tiles/validators.py
+++ b/src/xpublish_tiles/validators.py
@@ -5,7 +5,7 @@ from pyproj import CRS
 from pyproj.aoi import BBox
 from pyproj.exceptions import CRSError
 
-from xpublish_tiles.types import ImageFormat
+from xpublish_tiles.types import ImageFormat, OverviewSelectionStrategy
 
 
 def validate_colorscalerange(v: str | list[str] | None) -> tuple[float, float] | None:
@@ -131,6 +131,22 @@ def validate_legend_format(v: str | None):
     except ValueError as e:
         raise ValueError(
             f"legend format {format_str} is not valid. Options are: {', '.join(LegendFormat.__members__.keys())}",
+        ) from e
+
+
+def validate_overview_selection_strategy(
+    v: str | None,
+) -> OverviewSelectionStrategy | None:
+    if v is None:
+        return None
+    if isinstance(v, OverviewSelectionStrategy):
+        return v
+    try:
+        return OverviewSelectionStrategy(v.lower())
+    except ValueError as e:
+        raise ValueError(
+            f"overview_selection_strategy {v} is not valid. Options are: "
+            f"{', '.join(s.value for s in OverviewSelectionStrategy)}",
         ) from e
 
 

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -560,7 +560,12 @@ class TilesPlugin(Plugin):
             tms = morecantile.tms.get(tileMatrixSetId)
 
             # Extract dataset at appropriate resolution level for this zoom
-            level = get_resolution_level(datatree, zoom=tileMatrix, tms=tms)
+            level = get_resolution_level(
+                datatree,
+                zoom=tileMatrix,
+                tms=tms,
+                strategy=query.overview_selection_strategy,
+            )
             if level is not None:
                 dataset = level.dataset
                 resolution_level = level.path if level.path is not None else "root"

--- a/src/xpublish_tiles/xpublish/tiles/types.py
+++ b/src/xpublish_tiles/xpublish/tiles/types.py
@@ -6,13 +6,14 @@ from typing import Annotated, Any, Union
 import morecantile.models
 from pydantic import BaseModel, Field, field_validator
 
-from xpublish_tiles.types import ImageFormat, LegendFormat
+from xpublish_tiles.types import ImageFormat, LegendFormat, OverviewSelectionStrategy
 from xpublish_tiles.validators import (
     validate_color,
     validate_colormap,
     validate_colorscalerange,
     validate_image_format,
     validate_legend_format,
+    validate_overview_selection_strategy,
     validate_range_color,
     validate_style,
 )
@@ -1312,6 +1313,22 @@ class TileQuery(BaseModel):
             },
         ),
     ]
+    overview_selection_strategy: Annotated[
+        OverviewSelectionStrategy | None,
+        Field(
+            default=None,
+            json_schema_extra={
+                "description": "How to choose a multiscale overview for this zoom level: 'nearest' (closest pixel size), 'coarser' (never finer than the tile), or 'finer' (never coarser than the tile). Defaults to the server configuration.",
+            },
+        ),
+    ] = None
+
+    @field_validator("overview_selection_strategy", mode="before")
+    @classmethod
+    def validate_overview_selection_strategy(
+        cls, v: str | None
+    ) -> OverviewSelectionStrategy | None:
+        return validate_overview_selection_strategy(v)
 
     @field_validator("style", mode="before")
     @classmethod
@@ -1537,6 +1554,7 @@ TILES_FILTERED_QUERY_PARAMS: list[str] = [
     "abovemaxcolor",
     "belowmincolor",
     "render_errors",
+    "overview_selection_strategy",
 ]
 
 

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -4,6 +4,7 @@ from pyproj import CRS
 
 import xarray as xr
 from xarray import DataTree
+from xpublish_tiles.config import config
 from xpublish_tiles.multiscale import (
     get_crs,
     get_dataset,
@@ -11,6 +12,7 @@ from xpublish_tiles.multiscale import (
     scan_resolution_levels,
 )
 from xpublish_tiles.testing.datasets import GEOZARR_MULTISCALE, NATIVE_AT_ROOT_MULTISCALE
+from xpublish_tiles.types import OverviewSelectionStrategy
 
 
 def test_multiscale_has_multiple_levels():
@@ -181,6 +183,91 @@ def test_get_resolution_level_4x_pyramid_zoom_transitions(wgs84_tms):
         level = get_resolution_level(tree, zoom=zoom, tms=wgs84_tms)
         assert level is not None
         assert level.pixel_size == expected, f"zoom {zoom}"
+
+
+@pytest.mark.parametrize(
+    "strategy,expected_index",
+    [
+        (OverviewSelectionStrategy.NEAREST, 0),
+        (OverviewSelectionStrategy.COARSER, 1),
+        (OverviewSelectionStrategy.FINER, 0),
+    ],
+)
+def test_get_resolution_level_strategies_closer_to_finer(
+    wgs84_tms, strategy, expected_index
+):
+    # Tile pixel size sits between the two levels, closer to the finer one
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+    pixel_sizes = [tile_pixel_size / 1.9, tile_pixel_size * 4 / 1.9]
+    tree = _pyramid_tree(*pixel_sizes)
+
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms, strategy=strategy)
+    assert level is not None
+    assert level.pixel_size == pixel_sizes[expected_index]
+
+
+@pytest.mark.parametrize(
+    "strategy,expected_index",
+    [
+        (OverviewSelectionStrategy.NEAREST, 1),
+        (OverviewSelectionStrategy.COARSER, 1),
+        (OverviewSelectionStrategy.FINER, 0),
+    ],
+)
+def test_get_resolution_level_strategies_closer_to_coarser(
+    wgs84_tms, strategy, expected_index
+):
+    # Tile pixel size sits between the two levels, closer to the coarser one
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+    pixel_sizes = [tile_pixel_size / 2.1, tile_pixel_size * 4 / 2.1]
+    tree = _pyramid_tree(*pixel_sizes)
+
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms, strategy=strategy)
+    assert level is not None
+    assert level.pixel_size == pixel_sizes[expected_index]
+
+
+@pytest.mark.parametrize("strategy", list(OverviewSelectionStrategy))
+def test_get_resolution_level_strategies_exact_match(wgs84_tms, strategy):
+    # A level matching the tile exactly wins under every strategy
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+    tree = _pyramid_tree(tile_pixel_size / 4, tile_pixel_size, tile_pixel_size * 4)
+
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms, strategy=strategy)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size
+
+
+@pytest.mark.parametrize("strategy", list(OverviewSelectionStrategy))
+def test_get_resolution_level_strategies_fall_back_when_out_of_range(wgs84_tms, strategy):
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+
+    # All levels finer than the tile: nothing coarser to fall back to
+    tree = _pyramid_tree(tile_pixel_size / 8, tile_pixel_size / 4)
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms, strategy=strategy)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size / 4
+
+    # All levels coarser than the tile: nothing finer to fall back to
+    tree = _pyramid_tree(tile_pixel_size * 4, tile_pixel_size * 8)
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms, strategy=strategy)
+    assert level is not None
+    assert level.pixel_size == tile_pixel_size * 4
+
+
+def test_get_resolution_level_strategy_defaults_to_config(wgs84_tms):
+    tile_pixel_size = wgs84_tms.matrix(3).cellSize
+    pixel_sizes = [tile_pixel_size / 1.9, tile_pixel_size * 4 / 1.9]
+    tree = _pyramid_tree(*pixel_sizes)
+
+    level = get_resolution_level(tree, zoom=3, tms=wgs84_tms)
+    assert level is not None
+    assert level.pixel_size == pixel_sizes[0]
+
+    with config.set(overview_selection_strategy="coarser"):
+        level = get_resolution_level(tree, zoom=3, tms=wgs84_tms)
+    assert level is not None
+    assert level.pixel_size == pixel_sizes[1]
 
 
 def test_get_dataset_geozarr_high_zoom_returns_finest():

--- a/tests/test_xpublish/test_tiles/test_tiles_plugin.py
+++ b/tests/test_xpublish/test_tiles/test_tiles_plugin.py
@@ -1330,6 +1330,42 @@ def test_tilejson_minzoom_uses_coarsest_level():
 
 
 @pytest.mark.parametrize(
+    "strategy,expected_level",
+    [
+        ("nearest", "0"),
+        ("coarser", "1"),
+        ("finer", "0"),
+    ],
+)
+def test_overview_selection_strategy_query_param(strategy, expected_level):
+    """The query param overrides which overview a tile is rendered from."""
+    tree = GEOZARR_MULTISCALE.create()
+    rest = xpublish.Rest({"pyramid": tree}, plugins={"tiles": TilesPlugin()})
+    client = TestClient(rest.app)
+
+    # Zoom 7 tiles sit between the 0.01° and 0.02° levels, closer to 0.01°
+    response = client.get(
+        "/datasets/pyramid/tiles/WebMercatorQuad/7/43/60"
+        f"?variables=data&width=256&height=256&overview_selection_strategy={strategy}"
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Multiscale-Level"] == expected_level
+
+
+def test_overview_selection_strategy_invalid():
+    tree = GEOZARR_MULTISCALE.create()
+    rest = xpublish.Rest({"pyramid": tree}, plugins={"tiles": TilesPlugin()})
+    client = TestClient(rest.app)
+
+    response = client.get(
+        "/datasets/pyramid/tiles/WebMercatorQuad/7/43/60"
+        "?variables=data&width=256&height=256&overview_selection_strategy=bogus"
+    )
+    assert response.status_code == 422
+    assert "overview_selection_strategy" in response.text
+
+
+@pytest.mark.parametrize(
     "zoom,tile_row,tile_col,expected_level",
     [
         # Zoom 7: tile ~2.8° each, data (0.64°) fills ~23% - uses finest level


### PR DESCRIPTION
`get_resolution_level` always picked the nearest-resolution overview to the target tile pixel size. This PR introduces three different strategies

- NEAREST: nearest pixel size in log space, ties toward coarser
- COARSER: the finest level that is still no finer than the tile
- FINER: the coarsest level that is still no coarser than the tile

COARSER and FINER fall back to the closest available level when the tile's pixel size falls outside the range of levels; an exact match wins under all three.

The behavior selectable per-request via the `overview_selection_strategy` query parameter on the tile endpoint and globally via the config default (`nearest`, unchanged behavior).
