### PR TITLE
Explot rectilinearness for some conic projections

### DIFF
--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -1430,8 +1430,7 @@ class GridSystem(ABC):
             corner_x, corner_y = np.meshgrid(corner_x, corner_y)
         n0, n1 = corner_x.shape[0] - 1, corner_x.shape[1] - 1
         rings = np.empty((n0, n1, 5, 2), dtype=np.float64)
-        with NUMBA_THREADING_LOCK:
-            fill_rings_from_corners(rings, corner_x, corner_y)
+        fill_rings_from_corners(rings, corner_x, corner_y)
         return rings.reshape(-1, 5, 2)
 
     def coarsen_indices(

--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -28,18 +28,20 @@ from xpublish_tiles.lib import (
     VariableNotFoundError,
     _coarsen_indices_impl,
     _prevent_slice_overlap,
-    aeqd_to_4326,
     cf_get,
     crs_repr,
     fill_rings_from_corners,
-    is_degree_geographic,
     round_bbox,
     suppress_cf_dangling_ref_warnings,
     sync_load_async,
-    transformer_from_crs,
     unwrap,
 )
 from xpublish_tiles.logger import get_context_logger, log_duration, logger
+from xpublish_tiles.projections import (
+    aeqd_to_4326,
+    is_degree_geographic,
+    transformer_from_crs,
+)
 from xpublish_tiles.ugrid import MeshTopology, detect_mesh, load_connectivity
 from xpublish_tiles.utils import (
     NUMBA_THREADING_LOCK,

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Hashable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from functools import lru_cache, partial
+from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any, cast
 
@@ -27,6 +27,12 @@ from skimage.restoration import unwrap_phase
 
 import xarray as xr
 from xpublish_tiles.config import config
+from xpublish_tiles.projections import (
+    WEB_MERCATOR,
+    epsg4326to3857,
+    has_null_datum_shift,
+    is_degree_geographic,
+)
 from xpublish_tiles.utils import NUMBA_THREADING_LOCK
 
 if TYPE_CHECKING:
@@ -38,10 +44,6 @@ if TYPE_CHECKING:
     )
     from xpublish_tiles.types import DataType
 from xpublish_tiles.logger import logger
-
-WGS84_SEMI_MAJOR_AXIS = np.float64(6378137.0)  # from proj
-M_PI = 3.14159265358979323846  # from proj
-M_2_PI = 6.28318530717958647693  # from proj
 
 
 def unwrap(data: np.ndarray, *, width: float, axis: int | None = None) -> np.ndarray:
@@ -322,14 +324,6 @@ def sync_load_async(obj: xr.DataArray | xr.Dataset) -> None:
     EXECUTOR.submit(lambda: asyncio.run(obj.load_async())).result()
 
 
-# 4326 with order of axes reversed.
-OTHER_4326 = pyproj.CRS.from_user_input("WGS 84 (CRS84)")
-WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
-
-# https://pyproj4.github.io/pyproj/stable/advanced_examples.html#caching-pyproj-objects
-transformer_from_crs = lru_cache(partial(pyproj.Transformer.from_crs, always_xy=True))
-
-
 # benchmarked with
 # import numpy as np
 # import pyproj
@@ -366,114 +360,6 @@ def get_transform_chunk_size(da: xr.DataArray):
     chunk_size = config.get("transform_chunk_size")
     # This way the chunks are C-contiguous and we avoid a memory copy inside pyproj \m/
     return (max(chunk_size * chunk_size // da.shape[-1], 1), da.shape[-1])
-
-
-def is_degree_geographic(crs: CRS) -> bool:
-    """True for any geographic CRS with lon/lat axes in degrees (EPSG:4326,
-    CRS84, custom spherical datums like HEALPix's, etc.). The 4326-fastpath
-    in :func:`transform_coordinates` uses this to skip the pyproj roundtrip
-    and just wrap lon to [-180, 180], which is valid for all such CRSes —
-    any residual datum shift is sub-meter and below pixel resolution.
-    """
-    return crs.is_geographic and all(ax.unit_name == "degree" for ax in crs.axis_info)
-
-
-# Below this, treating the source lon/lat as WGS84 lon/lat is sub-pixel at any
-# zoom we serve, so the numpy fastpaths may skip pyproj's datum step.
-MAX_DATUM_SHIFT_METERS = 1.0
-_PROBE_SIDE = 5
-
-
-@lru_cache
-def has_null_datum_shift(crs: CRS) -> bool:
-    """True when `crs` lon/lat may be treated as WGS84 lon/lat.
-
-    Probes the datum step over the CRS's area of use rather than pattern-matching
-    operation names: proj picks the operation per point, and a "null" one (e.g.
-    EPSG:1188 NAD83->WGS84) is indistinguishable from a ballpark fallback taken
-    because a shift grid is missing. Either way, what matters is the displacement.
-    """
-    lon, lat = _area_of_use_grid(crs, _PROBE_SIDE)
-    x, y = transformer_from_crs(crs, 4326).transform(lon, lat)
-    finite = np.isfinite(x) & np.isfinite(y)
-    if not finite.any():
-        return False
-    dlon = (x - lon)[finite]
-    dlon = (dlon + 180.0) % 360.0 - 180.0
-    shift = np.hypot(dlon * np.cos(np.deg2rad(lat[finite])), (y - lat)[finite]) * 111320
-    return bool(shift.max() < MAX_DATUM_SHIFT_METERS)
-
-
-def _area_of_use_grid(crs: CRS, side: int) -> tuple[np.ndarray, np.ndarray]:
-    """Flattened lon/lat sample grid covering the CRS's area of use."""
-    area = crs.area_of_use
-    west, south, east, north = (
-        (area.west, area.south, area.east, area.north)
-        if area is not None
-        else (-180.0, -85.0, 180.0, 85.0)
-    )
-    if east < west:
-        east += 360.0
-    lon, lat = np.meshgrid(np.linspace(west, east, side), np.linspace(south, north, side))
-    return lon.ravel(), lat.ravel()
-
-
-def epsg4326to3857(lon: np.ndarray, lat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    a = WGS84_SEMI_MAJOR_AXIS
-
-    x = np.asarray(lon, dtype=np.float64, copy=True)
-    y = np.asarray(lat, dtype=np.float64, copy=True)
-
-    # Only normalize longitude values that are outside the [-180, 180] range
-    # This preserves precision for values already in the valid range
-    # pyproj accepts both -180 and 180 as valid values without wrapping
-    needs_normalization = (x > 180) | (x < -180)
-
-    np.deg2rad(x, out=x)
-    if np.any(needs_normalization):
-        # Only normalize the values that need it to preserve precision
-        # doing it this way matches proj
-        x[needs_normalization] = ((x[needs_normalization] + M_PI) % (2 * M_PI)) - M_PI
-    # Clamp latitude to avoid infinity at poles in-place
-    # Web Mercator is only valid between ~85.05 degrees
-    # Given our padding, we may be sending in data at latitudes poleward of MAX_LAT
-    # MAX_LAT = 85.051128779806604  # atan(sinh(pi)) * 180 / pi
-    # np.clip(y, -MAX_LAT, MAX_LAT, out=y)
-
-    # Y coordinate: use more stable formula for large latitudes
-    # Using: y = a * asinh(tan(φ)) for better numerical stability
-    # following the proj formula
-    # https://github.com/OSGeo/PROJ/blob/ff43c46b19802f5953a1546b05f59c5b9ee65795/src/projections/merc.cpp#L14
-    # https://proj.org/en/stable/operations/projections/merc.html#forward-projection
-    # Note: WebMercator uses the "spherical form"
-    np.deg2rad(y, out=y)
-    np.tan(y, out=y)
-    np.arcsinh(y, out=y)
-
-    x *= a
-    y *= a
-
-    return x, y
-
-
-def aeqd_to_4326(
-    x_m: np.ndarray,
-    y_m: np.ndarray,
-    center_lat: float,
-    center_lon: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Fast azimuthal equidistant (meters) to EPSG:4326 (degrees) conversion.
-
-    Uses flat-earth approximation. Accurate to 0.3% at 300km from center.
-    ~200x faster than pyproj for large arrays. Modifies x_m and y_m in place.
-    """
-    meters_per_deg_lat = 111320.0
-    meters_per_deg_lon = 111320.0 * np.cos(np.radians(center_lat))
-    x_m /= meters_per_deg_lon
-    x_m += center_lon
-    y_m /= meters_per_deg_lat
-    y_m += center_lat
-    return x_m, y_m
 
 
 def slices_from_chunks(chunks):

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -34,7 +34,7 @@ from xpublish_tiles.projections import (
     has_null_datum_shift,
     is_degree_geographic,
 )
-from xpublish_tiles.utils import NUMBA_THREADING_LOCK
+from xpublish_tiles.utils import NUMBA_PARALLEL
 
 if TYPE_CHECKING:
     from xpublish_tiles.grids import (
@@ -787,14 +787,14 @@ def polygons_from_rings(rings: np.ndarray):
     return PolygonArray(polys)
 
 
-@numba.njit(parallel=True, cache=True, boundscheck=False)
+@numba.njit(nogil=True, cache=True, boundscheck=False)
 def fill_rings_from_corners(out, corner_x, corner_y):
     """Fill a (n0, n1, 5, 2) ring array from a (n0+1, n1+1) corner grid.
 
     Ring order: (i,j), (i,j+1), (i+1,j+1), (i+1,j), (i,j) [close].
     """
     n0, n1 = out.shape[0], out.shape[1]
-    for i in numba.prange(n0):  # ty: ignore[not-iterable]
+    for i in range(n0):
         for j in range(n1):
             out[i, j, 0, 0] = corner_x[i, j]
             out[i, j, 0, 1] = corner_y[i, j]
@@ -927,7 +927,7 @@ def create_listed_colormap_from_dict(
     return colors
 
 
-@numba.jit(nopython=True, parallel=True, cache=True)
+@numba.jit(nopython=True, parallel=NUMBA_PARALLEL, nogil=True, cache=True)
 def _coarsen_nanmean_2d(arr, fy, fx, out):
     """Coarsen with nanmean, handling incomplete edge windows."""
     ny_out, nx_out = out.shape
@@ -971,8 +971,7 @@ def coarsen_mean_pad(da: xr.DataArray, factors: dict[str, int]) -> xr.DataArray:
 
     fy, fx = tuple(factors.get(str(dim), 1) for dim in dims)
     out = np.empty((math.ceil(H / fy), math.ceil(W / fx)), dtype=np.float64)
-    with NUMBA_THREADING_LOCK:
-        _coarsen_nanmean_2d(arr, fy, fx, out)
+    _coarsen_nanmean_2d(arr, fy, fx, out)
     return xr.DataArray(out, dims=dims, name=da.name)
 
 

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -523,14 +523,14 @@ async def transform_coordinates(
         return inx.copy(data=newx), iny.copy(data=newy)
 
     # A conic source into a cylindrical target factors through polar coordinates
-    # about the cone apex. Rectilinear input never gets broadcast: the kernel
-    # forms the outer product itself.
+    # about the cone apex. We can do a bunch of operations on 1D vectors and then
+    # form the outer product itself. So the rendering still always gets curvilinear inputs,
+    # just that some intermediates are much faster to compute for input rectilinear grids.
     factored = conic_to_cylindrical(transformer.source_crs, transformer.target_crs)
     if factored is not None:
         rectilinear = inx.ndim == 1 and iny.ndim == 1
-        result = await async_run(
-            partial(factored.transform, grid=rectilinear), inx.data, iny.data
-        )
+        convert = factored.transform_grid if rectilinear else factored.transform
+        result = await async_run(convert, inx.data, iny.data)
         if result is not None:
             dims = inx.dims + iny.dims if rectilinear else inx.dims
             coords = {inx.name: inx.variable, iny.name: iny.variable}

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -29,6 +29,7 @@ import xarray as xr
 from xpublish_tiles.config import config
 from xpublish_tiles.projections import (
     WEB_MERCATOR,
+    conic_to_cylindrical,
     epsg4326to3857,
     has_null_datum_shift,
     is_degree_geographic,
@@ -520,6 +521,24 @@ async def transform_coordinates(
         _clamp_infinite(newx)
         _clamp_infinite(newy)
         return inx.copy(data=newx), iny.copy(data=newy)
+
+    # A conic source into a cylindrical target factors through polar coordinates
+    # about the cone apex. Rectilinear input never gets broadcast: the kernel
+    # forms the outer product itself.
+    factored = conic_to_cylindrical(transformer.source_crs, transformer.target_crs)
+    if factored is not None:
+        rectilinear = inx.ndim == 1 and iny.ndim == 1
+        result = await async_run(
+            partial(factored.transform, grid=rectilinear), inx.data, iny.data
+        )
+        if result is not None:
+            dims = inx.dims + iny.dims if rectilinear else inx.dims
+            coords = {inx.name: inx.variable, iny.name: iny.variable}
+            newX = xr.DataArray(result[0], dims=dims, coords=coords, name=inx.name)
+            newY = xr.DataArray(result[1], dims=dims, coords=coords, name=iny.name)
+            _clamp_infinite(newX.data)
+            _clamp_infinite(newY.data)
+            return newX, newY
 
     # Broadcast coordinates
     # FIXME: dropping indexes is a workaround for broadcasting RasterIndex

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -324,6 +324,7 @@ def sync_load_async(obj: xr.DataArray | xr.Dataset) -> None:
 
 # 4326 with order of axes reversed.
 OTHER_4326 = pyproj.CRS.from_user_input("WGS 84 (CRS84)")
+WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
 
 # https://pyproj4.github.io/pyproj/stable/advanced_examples.html#caching-pyproj-objects
 transformer_from_crs = lru_cache(partial(pyproj.Transformer.from_crs, always_xy=True))
@@ -375,6 +376,46 @@ def is_degree_geographic(crs: CRS) -> bool:
     any residual datum shift is sub-meter and below pixel resolution.
     """
     return crs.is_geographic and all(ax.unit_name == "degree" for ax in crs.axis_info)
+
+
+# Below this, treating the source lon/lat as WGS84 lon/lat is sub-pixel at any
+# zoom we serve, so the numpy fastpaths may skip pyproj's datum step.
+MAX_DATUM_SHIFT_METERS = 1.0
+_PROBE_SIDE = 5
+
+
+@lru_cache
+def has_null_datum_shift(crs: CRS) -> bool:
+    """True when `crs` lon/lat may be treated as WGS84 lon/lat.
+
+    Probes the datum step over the CRS's area of use rather than pattern-matching
+    operation names: proj picks the operation per point, and a "null" one (e.g.
+    EPSG:1188 NAD83->WGS84) is indistinguishable from a ballpark fallback taken
+    because a shift grid is missing. Either way, what matters is the displacement.
+    """
+    lon, lat = _area_of_use_grid(crs, _PROBE_SIDE)
+    x, y = transformer_from_crs(crs, 4326).transform(lon, lat)
+    finite = np.isfinite(x) & np.isfinite(y)
+    if not finite.any():
+        return False
+    dlon = (x - lon)[finite]
+    dlon = (dlon + 180.0) % 360.0 - 180.0
+    shift = np.hypot(dlon * np.cos(np.deg2rad(lat[finite])), (y - lat)[finite]) * 111320
+    return bool(shift.max() < MAX_DATUM_SHIFT_METERS)
+
+
+def _area_of_use_grid(crs: CRS, side: int) -> tuple[np.ndarray, np.ndarray]:
+    """Flattened lon/lat sample grid covering the CRS's area of use."""
+    area = crs.area_of_use
+    west, south, east, north = (
+        (area.west, area.south, area.east, area.north)
+        if area is not None
+        else (-180.0, -85.0, 180.0, 85.0)
+    )
+    if east < west:
+        east += 360.0
+    lon, lat = np.meshgrid(np.linspace(west, east, side), np.linspace(south, north, side))
+    return lon.ravel(), lat.ravel()
 
 
 def epsg4326to3857(lon: np.ndarray, lat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -577,10 +618,17 @@ async def transform_coordinates(
     if transformer.source_crs == transformer.target_crs:
         return inx, iny
 
-    # preserve rectilinear-ness by reimplementing this (easy) transform
-    if (inx.ndim == 1 and iny.ndim == 1) and (
-        transformer == transformer_from_crs(4326, 3857)
-        or transformer == transformer_from_crs(OTHER_4326, 3857)
+    # preserve rectilinear-ness by reimplementing this (easy) transform.
+    # Any degree-geographic source whose datum step is a no-op qualifies (4326,
+    # CRS84, NAD83, ETRS89, ...) -- the spherical WebMercator formula only
+    # consumes degrees. Datums with a real shift (NAD27, OSGB36: >100m) fall
+    # through to pyproj.
+    if (
+        inx.ndim == 1
+        and iny.ndim == 1
+        and transformer.target_crs == WEB_MERCATOR
+        and is_degree_geographic(transformer.source_crs)
+        and has_null_datum_shift(transformer.source_crs)
     ):
         newx, newy = epsg4326to3857(inx.data, iny.data)
         _clamp_infinite(newx)

--- a/src/xpublish_tiles/pipeline.py
+++ b/src/xpublish_tiles/pipeline.py
@@ -52,11 +52,13 @@ from xpublish_tiles.lib import (
     sum_tuples,
     timedelta_to_iso8601,
     transform_coordinates,
-    transformer_from_crs,
     unwrap,
     validate_colormap_for_datatype,
 )
 from xpublish_tiles.logger import get_context_logger, log_duration
+from xpublish_tiles.projections import (
+    transformer_from_crs,
+)
 from xpublish_tiles.types import (
     ContinuousData,
     DataType,

--- a/src/xpublish_tiles/projections.py
+++ b/src/xpublish_tiles/projections.py
@@ -13,8 +13,6 @@ import numpy as np
 import pyproj
 from pyproj import CRS
 
-from xpublish_tiles.utils import NUMBA_THREADING_LOCK
-
 _XY = tuple[np.ndarray, np.ndarray]
 
 WGS84_SEMI_MAJOR_AXIS = np.float64(6378137.0)  # from proj
@@ -196,13 +194,13 @@ def _project(dx, dy, slope, offset, rho_lo, inv_h, y_nodes):
     )
 
 
-@numba.njit(parallel=True, cache=True, boundscheck=False)
+@numba.njit(nogil=True, cache=True, boundscheck=False)
 def _grid_kernel(
     x, y, apex_x, apex_y, slope, offset, rho_lo, inv_h, y_nodes, out_x, out_y
 ):
     """Rectilinear source: the 1D axes are never broadcast."""
     missed = 0
-    for i in numba.prange(x.size):  # ty: ignore[not-iterable]
+    for i in range(x.size):
         dx = x[i] - apex_x
         for j in range(y.size):
             out_x[i, j], out_y[i, j], outside = _project(
@@ -212,13 +210,13 @@ def _grid_kernel(
     return missed
 
 
-@numba.njit(parallel=True, cache=True, boundscheck=False)
+@numba.njit(nogil=True, cache=True, boundscheck=False)
 def _points_kernel(
     x, y, apex_x, apex_y, slope, offset, rho_lo, inv_h, y_nodes, out_x, out_y
 ):
     """Curvilinear source: x and y are matching arrays of points."""
     missed = 0
-    for k in numba.prange(x.size):  # ty: ignore[not-iterable]
+    for k in range(x.size):
         out_x[k], out_y[k], outside = _project(
             x[k] - apex_x, apex_y - y[k], slope, offset, rho_lo, inv_h, y_nodes
         )
@@ -259,20 +257,19 @@ class ConicToCylindrical:
         return None if missed else (out_x, out_y)
 
     def _run(self, kernel, x, y, out_x, out_y):
-        with NUMBA_THREADING_LOCK:
-            return kernel(
-                np.ascontiguousarray(x, dtype=np.float64),
-                np.ascontiguousarray(y, dtype=np.float64),
-                self.apex_x,
-                self.apex_y,
-                self.x_slope,
-                self.x_offset,
-                self.rho_lo,
-                self.inv_h,
-                self.y_nodes,
-                out_x,
-                out_y,
-            )
+        return kernel(
+            np.ascontiguousarray(x, dtype=np.float64),
+            np.ascontiguousarray(y, dtype=np.float64),
+            self.apex_x,
+            self.apex_y,
+            self.x_slope,
+            self.x_offset,
+            self.rho_lo,
+            self.inv_h,
+            self.y_nodes,
+            out_x,
+            out_y,
+        )
 
 
 def _cone_apex(x: np.ndarray, y: np.ndarray) -> tuple[float, float]:

--- a/src/xpublish_tiles/projections.py
+++ b/src/xpublish_tiles/projections.py
@@ -5,6 +5,7 @@ async orchestration lives in :mod:`xpublish_tiles.lib`.
 """
 
 import warnings
+from dataclasses import dataclass
 from functools import lru_cache, partial
 
 import numba
@@ -14,6 +15,8 @@ from pyproj import CRS
 
 from xpublish_tiles.utils import NUMBA_THREADING_LOCK
 
+_XY = tuple[np.ndarray, np.ndarray]
+
 WGS84_SEMI_MAJOR_AXIS = np.float64(6378137.0)  # from proj
 M_PI = 3.14159265358979323846  # from proj
 M_2_PI = 6.28318530717958647693  # from proj
@@ -21,6 +24,11 @@ M_2_PI = 6.28318530717958647693  # from proj
 # 4326 with order of axes reversed.
 OTHER_4326 = pyproj.CRS.from_user_input("WGS 84 (CRS84)")
 WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
+
+# Below this, treating the source lon/lat as WGS84 lon/lat is sub-pixel at any
+# zoom we serve, so the numpy fastpaths may skip pyproj's datum step.
+MAX_DATUM_SHIFT_METERS = 1.0
+_PROBE_SIDE = 5
 
 # https://pyproj4.github.io/pyproj/stable/advanced_examples.html#caching-pyproj-objects
 transformer_from_crs = lru_cache(partial(pyproj.Transformer.from_crs, always_xy=True))
@@ -31,16 +39,10 @@ def is_degree_geographic(crs: CRS) -> bool:
     CRS84, custom spherical datums like HEALPix's, etc.). The 4326-fastpath
     in :func:`xpublish_tiles.lib.transform_coordinates` uses this to skip the
     pyproj roundtrip and just wrap lon to [-180, 180], which is valid for all
-    such CRSes — any residual datum shift is sub-meter and below pixel
+    such CRSes. We assume any residual datum shift is sub-meter and below pixel
     resolution.
     """
     return crs.is_geographic and all(ax.unit_name == "degree" for ax in crs.axis_info)
-
-
-# Below this, treating the source lon/lat as WGS84 lon/lat is sub-pixel at any
-# zoom we serve, so the numpy fastpaths may skip pyproj's datum step.
-MAX_DATUM_SHIFT_METERS = 1.0
-_PROBE_SIDE = 5
 
 
 @lru_cache
@@ -137,12 +139,12 @@ def aeqd_to_4326(
 
 # --- conic source -> normal-cylindrical target -------------------------------
 #
-# A conic projection is polar about the cone apex: rho depends only on latitude,
-# theta only on longitude. A normal-aspect cylindrical target (Web Mercator,
-# plate carree) has X depending only on longitude and Y only on latitude. So the
-# composed map factors: X is affine in theta, Y is a function of rho alone. Every
-# transcendental collapses to one dimension, and the 2D work left is a hypot, an
-# arctan2 and a table lookup.
+# A conic projection is polar about the cone apex. That mean ρ(latitude and
+# θ(longitude). A normal-aspect cylindrical target (Web Mercator,
+# plate carree) has X(longitude) and Y(latitude). So the
+# composed map factors: X is affine in θ, Y is a function of ρ alone.
+# Then every transcendental collapses to one dimension,
+# and the 2D work left is a hypot, an arctan2 and a table lookup.
 #
 # Phase 2, not implemented: the mirror case, a geographic source into a conic
 # target, which is what the CanadianNAD83_LCC tile matrix set needs. There theta
@@ -150,117 +152,117 @@ def aeqd_to_4326(
 # is an outer product — both reductions stay 1D and only four elementwise
 # multiplies remain. Bigger win than this direction, same apex/n recovery.
 
-CONIC_PROJ_NAMES = frozenset({"aea", "lcc"})
+# Conic source CRSes that factor cleanly into Web Mercator. Being on this list
+# asserts two things, both re-checked against pyproj by tests/test_projections.py:
+# the composed map really is a function of (rho, theta), and a table of
+# _CONIC_NODES nodes holds CONIC_TOLERANCE_METERS across the area of use. Neither
+# is safe to assume for an arbitrary conic -- a position-dependent datum step
+# breaks the first (BD72 -> WGS84 misses by metres) and Arctic latitudes break
+# the second (EPSG:3978) -- so add a CRS here only with a test beside it.
+CONIC_ALLOWLIST = frozenset(
+    {
+        5070,  # NAD83 / Conus Albers
+        6350,  # NAD83(2011) / Conus Albers
+        3005,  # NAD83 / BC Albers
+    }
+)
 # Interpolation error budget for the Y(rho) table. Well below a pixel at any zoom.
 CONIC_TOLERANCE_METERS = 0.01
-_CONIC_VALIDATION_SIDE = 16
-_CONIC_COARSE_NODES = 1024
-_CONIC_MAX_NODES = 1 << 17
-# The area of use understates the projected extent a raster can occupy.
-_CONIC_RANGE_MARGIN = 0.3
+_CONIC_PROJ_NAMES = frozenset({"aea", "lcc"})
+_CONIC_NODES = 1 << 16
+_CONIC_SAMPLE_SIDE = 16
+# A raster reaches past its CRS's area of use, so widen the table's latitude span.
+_CONIC_LAT_PAD = 5.0
+# Y diverges at the poles, so keep the padding short of them. It is a guard, not
+# a tuning knob: Y'' grows as 1/rho^2 up there, and a CRS reaching that far needs
+# far more nodes for the same tolerance, which is why EPSG:3978 is not allowed.
+_CONIC_MAX_LAT = 89.5
 
 
-@numba.njit(parallel=True, cache=True, boundscheck=False)
-def _conic_kernel(x, y, apex_x, apex_y, slope, offset, lo, inv_h, y_nodes, out_x, out_y):
-    """One fused pass: no temporaries, no binary search.
-
-    ``sqrt(dx*dx + dy*dy)`` replaces ``np.hypot`` (the overflow guards cost more
-    than they buy at projected-coordinate magnitudes) and the uniform node
-    spacing turns the table lookup into an index computation. Returns a count of
-    points outside the table so the caller can fall back.
-    """
-    flat_x = x.ravel()
-    flat_y = y.ravel()
-    flat_out_x = out_x.ravel()
-    flat_out_y = out_y.ravel()
+@numba.njit(inline="always", cache=True)
+def _project(dx, dy, slope, offset, rho_lo, inv_h, y_nodes):
+    """One point. theta is exact; Y is a lookup in the uniform table."""
+    scaled = (np.sqrt(dx * dx + dy * dy) - rho_lo) * inv_h
     last = y_nodes.size - 2
-    outside = 0
-    for k in numba.prange(flat_x.size):  # ty: ignore[not-iterable]
-        dx = flat_x[k] - apex_x
-        dy = apex_y - flat_y[k]
-        flat_out_x[k] = np.arctan2(dx, dy) * slope + offset
-        scaled = (np.sqrt(dx * dx + dy * dy) - lo) * inv_h
-        i = int(scaled)
-        if i < 0:
-            i = 0
-            outside += 1
-        elif i > last:
-            i = last
-            outside += 1
-        frac = scaled - i
-        below = y_nodes[i]
-        flat_out_y[k] = below + frac * (y_nodes[i + 1] - below)
-    return outside
+    k = int(scaled)
+    outside = k < 0 or k > last
+    if outside:
+        k = min(max(k, 0), last)
+    below = y_nodes[k]
+    return (
+        np.arctan2(dx, dy) * slope + offset,
+        below + (scaled - k) * (y_nodes[k + 1] - below),
+        outside,
+    )
 
 
 @numba.njit(parallel=True, cache=True, boundscheck=False)
-def _conic_kernel_1d(
-    x, y, apex_x, apex_y, slope, offset, lo, inv_h, y_nodes, out_x, out_y
+def _grid_kernel(
+    x, y, apex_x, apex_y, slope, offset, rho_lo, inv_h, y_nodes, out_x, out_y
 ):
-    """Rectilinear source: take the 1D axes and skip broadcasting them.
-
-    The outer product is formed inside the loop, so nothing the size of the
-    output is allocated for the inputs.
-    """
-    last = y_nodes.size - 2
-    outside = 0
+    """Rectilinear source: the 1D axes are never broadcast."""
+    missed = 0
     for i in numba.prange(x.size):  # ty: ignore[not-iterable]
         dx = x[i] - apex_x
         for j in range(y.size):
-            dy = apex_y - y[j]
-            out_x[i, j] = np.arctan2(dx, dy) * slope + offset
-            scaled = (np.sqrt(dx * dx + dy * dy) - lo) * inv_h
-            k = int(scaled)
-            if k < 0:
-                k = 0
-                outside += 1
-            elif k > last:
-                k = last
-                outside += 1
-            below = y_nodes[k]
-            out_y[i, j] = below + (scaled - k) * (y_nodes[k + 1] - below)
-    return outside
+            out_x[i, j], out_y[i, j], outside = _project(
+                dx, apex_y - y[j], slope, offset, rho_lo, inv_h, y_nodes
+            )
+            missed += outside
+    return missed
 
 
+@numba.njit(parallel=True, cache=True, boundscheck=False)
+def _points_kernel(
+    x, y, apex_x, apex_y, slope, offset, rho_lo, inv_h, y_nodes, out_x, out_y
+):
+    """Curvilinear source: x and y are matching arrays of points."""
+    missed = 0
+    for k in numba.prange(x.size):  # ty: ignore[not-iterable]
+        out_x[k], out_y[k], outside = _project(
+            x[k] - apex_x, apex_y - y[k], slope, offset, rho_lo, inv_h, y_nodes
+        )
+        missed += outside
+    return missed
+
+
+@dataclass(frozen=True)
 class ConicToCylindrical:
-    """Factored conic -> normal-cylindrical transform.
+    """``X = x_slope * theta + x_offset``; ``Y`` interpolated from ``y_nodes``.
 
-    ``X = x_slope * theta + x_offset`` exactly; ``Y = interp(rho)`` from a table
-    dense enough for :data:`CONIC_TOLERANCE_METERS`.
+    Both transforms return None if any point misses the table, so the caller can
+    fall back to pyproj.
     """
 
-    __slots__ = ("apex_x", "apex_y", "inv_h", "rho_lo", "x_offset", "x_slope", "y_nodes")
+    apex_x: float
+    apex_y: float
+    x_slope: float
+    x_offset: float
+    rho_lo: float
+    inv_h: float
+    y_nodes: np.ndarray
 
-    def __init__(self, apex_x, apex_y, x_slope, x_offset, rho_lo, rho_hi, y_nodes):
-        self.apex_x = apex_x
-        self.apex_y = apex_y
-        self.x_slope = x_slope
-        self.x_offset = x_offset
-        self.rho_lo = rho_lo
-        self.inv_h = (y_nodes.size - 1) / (rho_hi - rho_lo)
-        self.y_nodes = y_nodes
+    def transform(self, x: np.ndarray, y: np.ndarray) -> _XY | None:
+        """x and y are matching arrays of points, of any shape."""
+        out_x = np.empty(x.shape, dtype=np.float64)
+        out_y = np.empty(x.shape, dtype=np.float64)
+        missed = self._run(
+            _points_kernel, np.ravel(x), np.ravel(y), out_x.ravel(), out_y.ravel()
+        )
+        return None if missed else (out_x, out_y)
 
-    def transform(
-        self, x: np.ndarray, y: np.ndarray, *, grid: bool = False
-    ) -> tuple[np.ndarray, np.ndarray] | None:
-        """Returns None when any rho falls outside the table, so callers fall back.
+    def transform_grid(self, x: np.ndarray, y: np.ndarray) -> _XY | None:
+        """x and y are the 1D axes of a rectilinear grid; output is (x.size, y.size)."""
+        out_x = np.empty((x.size, y.size), dtype=np.float64)
+        out_y = np.empty((x.size, y.size), dtype=np.float64)
+        missed = self._run(_grid_kernel, x, y, out_x, out_y)
+        return None if missed else (out_x, out_y)
 
-        With ``grid``, 1D x and y are the axes of a rectilinear grid and the
-        output has shape ``(x.size, y.size)``. Otherwise x and y are matching
-        arrays of points. Two 1D arrays are ambiguous between the two, hence the
-        explicit flag.
-        """
-        x = np.asarray(x, dtype=np.float64)
-        y = np.asarray(y, dtype=np.float64)
-        rectilinear = grid and x.ndim == 1 and y.ndim == 1
-        shape = (x.size, y.size) if rectilinear else x.shape
-        out_x = np.empty(shape, dtype=np.float64)
-        out_y = np.empty(shape, dtype=np.float64)
-        kernel = _conic_kernel_1d if rectilinear else _conic_kernel
+    def _run(self, kernel, x, y, out_x, out_y):
         with NUMBA_THREADING_LOCK:
-            outside = kernel(
-                x,
-                y,
+            return kernel(
+                np.ascontiguousarray(x, dtype=np.float64),
+                np.ascontiguousarray(y, dtype=np.float64),
                 self.apex_x,
                 self.apex_y,
                 self.x_slope,
@@ -271,178 +273,108 @@ class ConicToCylindrical:
                 out_x,
                 out_y,
             )
-        return None if outside else (out_x, out_y)
 
 
-def _cone_geometry(crs: CRS) -> tuple[float, float, float] | None:
-    """(apex_x, apex_y, n) in the CRS's own units, from its parameters.
+def _cone_apex(x: np.ndarray, y: np.ndarray) -> tuple[float, float]:
+    """Intersect two meridians of a projected lat/lon grid.
 
-    Snyder's conic constants. The ellipsoid is always metric while the grid may
-    not be (US survey feet), hence the unit scaling.
+    Meridians are straight lines through the apex, so two of them fix it. Shorter
+    than Snyder's constants, and it needs no per-projection formula, no ellipsoid
+    and no unit handling.
+    """
+    first, last = np.stack([x[:, 0], y[:, 0]], -1), np.stack([x[:, -1], y[:, -1]], -1)
+    origin, along = first[0], first[-1] - first[0]
+    other_origin, other_along = last[0], last[-1] - last[0]
+    matrix = np.stack([along, -other_along], -1)
+    steps = np.linalg.solve(matrix, other_origin - origin)
+    apex = origin + steps[0] * along
+    return float(apex[0]), float(apex[1])
+
+
+@lru_cache
+def _conic_signature(crs: CRS) -> tuple | None:
+    """The parameters that define the cone, or None if the CRS is not conic.
+
+    Matching on these rather than on the EPSG code lets a dataset carrying the
+    same projection as a bare PROJ string or a CF grid mapping -- no EPSG code
+    attached -- still reach the fastpath.
     """
     with warnings.catch_warnings():
-        # to_dict() warns that a PROJ string loses information. We only read the
+        # to_dict() warns that a PROJ string loses information; we only read the
         # conic parameters, which it keeps.
         warnings.simplefilter("ignore", UserWarning)
         params = crs.to_dict()
-    if params.get("proj") not in CONIC_PROJ_NAMES:
+    if params.get("proj") not in _CONIC_PROJ_NAMES:
         return None
-    ellipsoid = crs.ellipsoid
-    if ellipsoid is None or ellipsoid.semi_major_metre is None:
-        return None
-    unit = crs.axis_info[0].unit_conversion_factor
-    a = ellipsoid.semi_major_metre / unit
-    inverse_flattening = ellipsoid.inverse_flattening
-    f = 1.0 / inverse_flattening if inverse_flattening else 0.0
-    e = np.sqrt(2 * f - f * f)
-
     lat_1 = params.get("lat_1", 0.0)
-    phi1 = np.deg2rad(lat_1)
-    phi2 = np.deg2rad(params.get("lat_2", lat_1))
-    phi0 = np.deg2rad(params.get("lat_0", 0.0))
-    x_0 = params.get("x_0", 0.0) / unit
-    y_0 = params.get("y_0", 0.0) / unit
+    angles = (lat_1, params.get("lat_2", lat_1), params.get("lat_0", 0.0))
+    offsets = (params.get("lon_0", 0.0), params.get("x_0", 0.0), params.get("y_0", 0.0))
+    return (
+        params["proj"],
+        *(round(v, 9) for v in angles + offsets),
+        params.get("units"),
+        crs.datum.name if crs.datum is not None else None,
+    )
 
-    def m(phi):
-        return np.cos(phi) / np.sqrt(1 - e * e * np.sin(phi) ** 2)
 
-    def q(phi):
-        s = np.sin(phi)
-        if e == 0:
-            return 2 * s
-        return (1 - e * e) * (
-            s / (1 - e * e * s * s) - np.log((1 - e * s) / (1 + e * s)) / (2 * e)
-        )
-
-    def t(phi):
-        s = np.sin(phi)
-        if e == 0:
-            return np.tan(np.pi / 4 - phi / 2)
-        return np.tan(np.pi / 4 - phi / 2) / ((1 - e * s) / (1 + e * s)) ** (e / 2)
-
-    tangent = abs(phi1 - phi2) < 1e-12
-    if params["proj"] == "aea":
-        n = (
-            np.sin(phi1)
-            if tangent
-            else (m(phi1) ** 2 - m(phi2) ** 2) / (q(phi2) - q(phi1))
-        )
-        if n == 0:
-            return None
-        rho0 = a * np.sqrt(m(phi1) ** 2 + n * q(phi1) - n * q(phi0)) / n
-    else:
-        n = (
-            np.sin(phi1)
-            if tangent
-            else (np.log(m(phi1)) - np.log(m(phi2))) / (np.log(t(phi1)) - np.log(t(phi2)))
-        )
-        if n == 0:
-            return None
-        rho0 = a * (m(phi1) / (n * t(phi1) ** n)) * t(phi0) ** n
-    if not np.isfinite(rho0):
-        return None
-    return x_0, y_0 + rho0, float(n)
+@lru_cache
+def _allowed_conics() -> dict[tuple, CRS]:
+    """Allowlist signature -> the canonical CRS, which carries an area of use."""
+    allowed = {}
+    for code in CONIC_ALLOWLIST:
+        crs = CRS.from_epsg(code)
+        signature = _conic_signature(crs)
+        if signature is not None:
+            allowed[signature] = crs
+    return allowed
 
 
 @lru_cache
 def conic_to_cylindrical(source_crs: CRS, target_crs: CRS) -> ConicToCylindrical | None:
-    """Build the factored transform, or None if the map does not factor.
-
-    The parameters give the cone geometry; only a numeric check tells us whether
-    the *composed* map really is a function of (rho, theta). It is not when the
-    datum step is position-dependent (e.g. BD72 -> WGS84 misses by metres), and
-    the parameters alone cannot show that.
-    """
-    geometry = _cone_geometry(source_crs)
-    if geometry is None:
+    """Build the factored transform for an allowlisted conic source."""
+    signature = _conic_signature(source_crs)
+    if signature is None or signature not in _allowed_conics():
         return None
-    apex_x, apex_y, _ = geometry
+    canonical = _allowed_conics()[signature]
 
     to_source = transformer_from_crs(source_crs.geodetic_crs, source_crs)
     to_target = transformer_from_crs(source_crs, target_crs)
-    lon, lat = _area_of_use_grid(source_crs, _CONIC_VALIDATION_SIDE)
-    sx, sy = to_source.transform(lon, lat)
-    tx, ty = to_target.transform(sx, sy)
-    finite = np.isfinite(sx) & np.isfinite(sy) & np.isfinite(tx) & np.isfinite(ty)
-    if finite.sum() < 4:
-        return None
-    sx, sy, tx, ty = sx[finite], sy[finite], tx[finite], ty[finite]
+    # Sample the canonical CRS's area of use: an equivalent CRS built from a PROJ
+    # string has none, and a global fallback would stretch the table pole to pole.
+    lon, lat = _area_of_use_grid(canonical, _CONIC_SAMPLE_SIDE)
+    grid_x, grid_y = to_source.transform(lon, lat)
+    side = _CONIC_SAMPLE_SIDE
+    apex_x, apex_y = _cone_apex(grid_x.reshape(side, side), grid_y.reshape(side, side))
 
-    dx, dy = sx - apex_x, apex_y - sy
-    theta = np.arctan2(dx, dy)
-    rho = np.hypot(dx, dy)
-    x_slope, x_offset = np.polyfit(theta, tx, 1)
-
-    # The area of use is a lon/lat box, so a projected raster on this CRS reaches
-    # past it — its corners alone do. Pad generously, then clip back to where the
-    # target is finite (rho grows towards the far pole, where Web Mercator Y
-    # diverges). Anything still outside falls back to pyproj, so the margin is a
-    # performance choice, not a correctness one.
-    span = rho.max() - rho.min()
-    lo = max(rho.min() - _CONIC_RANGE_MARGIN * span, 0.0)
-    hi = rho.max() + _CONIC_RANGE_MARGIN * span
-    clipped = _finite_rho_range(to_target, apex_x, apex_y, lo, hi, rho.min(), rho.max())
-    if clipped is None:
-        return None
-    lo, hi = clipped
-
-    coarse = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, _CONIC_COARSE_NODES)
-    # Linear interpolation error is |Y''| h^2 / 8, so it falls as h^2. One coarse
-    # table sizes the final one.
-    curvature = np.abs(np.diff(coarse, 2)).max()
-    count = _CONIC_COARSE_NODES
-    if curvature > 0:
-        needed = _CONIC_COARSE_NODES * np.sqrt((curvature / 8) / CONIC_TOLERANCE_METERS)
-        count = int(np.clip(needed, _CONIC_COARSE_NODES, _CONIC_MAX_NODES))
-    y_nodes = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, count)
-    if not np.all(np.isfinite(y_nodes)):
-        return None
-
-    factored = ConicToCylindrical(
-        apex_x, apex_y, float(x_slope), float(x_offset), lo, hi, y_nodes
+    # rho depends on latitude alone, so the two padded latitude limits bound it.
+    edge_lat = np.clip(
+        [lat.min() - _CONIC_LAT_PAD, lat.max() + _CONIC_LAT_PAD],
+        -_CONIC_MAX_LAT,
+        _CONIC_MAX_LAT,
     )
-    check = factored.transform(sx, sy)
-    if check is None:
-        return None
-    if max(np.abs(check[0] - tx).max(), np.abs(check[1] - ty).max()) > (
-        CONIC_TOLERANCE_METERS
-    ):
-        return None
-    return factored
+    edge_x, edge_y = to_source.transform(np.full(2, lon[0]), edge_lat)
+    rho_lo, rho_hi = sorted(np.hypot(edge_x - apex_x, apex_y - edge_y))
+    y_nodes = _target_y(
+        to_target, apex_x, apex_y, np.linspace(rho_lo, rho_hi, _CONIC_NODES)
+    )
+
+    # X is affine in theta; two points would do, but a fit costs nothing.
+    theta = np.arctan2(grid_x - apex_x, apex_y - grid_y)
+    x_slope, x_offset = np.polyfit(theta, to_target.transform(grid_x, grid_y)[0], 1)
+
+    return ConicToCylindrical(
+        apex_x,
+        apex_y,
+        float(x_slope),
+        float(x_offset),
+        rho_lo,
+        (_CONIC_NODES - 1) / (rho_hi - rho_lo),
+        y_nodes,
+    )
 
 
-def _sample_y_of_rho(
-    to_target: pyproj.Transformer,
-    apex_x: float,
-    apex_y: float,
-    lo: float,
-    hi: float,
-    count: int,
+def _target_y(
+    to_target: pyproj.Transformer, apex_x: float, apex_y: float, rho: np.ndarray
 ) -> np.ndarray:
-    """Y along the theta=0 ray, i.e. the central meridian, as a function of rho."""
-    rho = np.linspace(lo, hi, count)
-    _, y = to_target.transform(np.full_like(rho, apex_x), apex_y - rho)
-    return y
-
-
-def _finite_rho_range(
-    to_target: pyproj.Transformer,
-    apex_x: float,
-    apex_y: float,
-    lo: float,
-    hi: float,
-    must_cover_lo: float,
-    must_cover_hi: float,
-) -> tuple[float, float] | None:
-    """Shrink [lo, hi] to the finite run around the range we must cover."""
-    rho = np.linspace(lo, hi, _CONIC_COARSE_NODES)
-    y = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, _CONIC_COARSE_NODES)
-    bad = np.flatnonzero(~np.isfinite(y))
-    if bad.size:
-        below = bad[rho[bad] < must_cover_lo]
-        above = bad[rho[bad] > must_cover_hi]
-        if below.size != bad.size - above.size:
-            return None  # a hole inside the range we need
-        lo = rho[below[-1] + 1] if below.size else lo
-        hi = rho[above[0] - 1] if above.size else hi
-    return (lo, hi) if hi > lo else None
+    """Y along the theta=0 ray, which is the central meridian."""
+    return to_target.transform(np.full_like(rho, apex_x), apex_y - rho)[1]

--- a/src/xpublish_tiles/projections.py
+++ b/src/xpublish_tiles/projections.py
@@ -4,11 +4,15 @@ Everything here is pure numpy/pyproj on raw arrays. The xarray-aware,
 async orchestration lives in :mod:`xpublish_tiles.lib`.
 """
 
+import warnings
 from functools import lru_cache, partial
 
+import numba
 import numpy as np
 import pyproj
 from pyproj import CRS
+
+from xpublish_tiles.utils import NUMBA_THREADING_LOCK
 
 WGS84_SEMI_MAJOR_AXIS = np.float64(6378137.0)  # from proj
 M_PI = 3.14159265358979323846  # from proj
@@ -129,3 +133,316 @@ def aeqd_to_4326(
     y_m /= meters_per_deg_lat
     y_m += center_lat
     return x_m, y_m
+
+
+# --- conic source -> normal-cylindrical target -------------------------------
+#
+# A conic projection is polar about the cone apex: rho depends only on latitude,
+# theta only on longitude. A normal-aspect cylindrical target (Web Mercator,
+# plate carree) has X depending only on longitude and Y only on latitude. So the
+# composed map factors: X is affine in theta, Y is a function of rho alone. Every
+# transcendental collapses to one dimension, and the 2D work left is a hypot, an
+# arctan2 and a table lookup.
+#
+# Phase 2, not implemented: the mirror case, a geographic source into a conic
+# target, which is what the CanadianNAD83_LCC tile matrix set needs. There theta
+# is 1D in lon and rho is 1D in lat, so x = rho*sin(theta), y = rho0 - rho*cos(theta)
+# is an outer product — both reductions stay 1D and only four elementwise
+# multiplies remain. Bigger win than this direction, same apex/n recovery.
+
+CONIC_PROJ_NAMES = frozenset({"aea", "lcc"})
+# Interpolation error budget for the Y(rho) table. Well below a pixel at any zoom.
+CONIC_TOLERANCE_METERS = 0.01
+_CONIC_VALIDATION_SIDE = 16
+_CONIC_COARSE_NODES = 1024
+_CONIC_MAX_NODES = 1 << 17
+# The area of use understates the projected extent a raster can occupy.
+_CONIC_RANGE_MARGIN = 0.3
+
+
+@numba.njit(parallel=True, cache=True, boundscheck=False)
+def _conic_kernel(x, y, apex_x, apex_y, slope, offset, lo, inv_h, y_nodes, out_x, out_y):
+    """One fused pass: no temporaries, no binary search.
+
+    ``sqrt(dx*dx + dy*dy)`` replaces ``np.hypot`` (the overflow guards cost more
+    than they buy at projected-coordinate magnitudes) and the uniform node
+    spacing turns the table lookup into an index computation. Returns a count of
+    points outside the table so the caller can fall back.
+    """
+    flat_x = x.ravel()
+    flat_y = y.ravel()
+    flat_out_x = out_x.ravel()
+    flat_out_y = out_y.ravel()
+    last = y_nodes.size - 2
+    outside = 0
+    for k in numba.prange(flat_x.size):  # ty: ignore[not-iterable]
+        dx = flat_x[k] - apex_x
+        dy = apex_y - flat_y[k]
+        flat_out_x[k] = np.arctan2(dx, dy) * slope + offset
+        scaled = (np.sqrt(dx * dx + dy * dy) - lo) * inv_h
+        i = int(scaled)
+        if i < 0:
+            i = 0
+            outside += 1
+        elif i > last:
+            i = last
+            outside += 1
+        frac = scaled - i
+        below = y_nodes[i]
+        flat_out_y[k] = below + frac * (y_nodes[i + 1] - below)
+    return outside
+
+
+@numba.njit(parallel=True, cache=True, boundscheck=False)
+def _conic_kernel_1d(
+    x, y, apex_x, apex_y, slope, offset, lo, inv_h, y_nodes, out_x, out_y
+):
+    """Rectilinear source: take the 1D axes and skip broadcasting them.
+
+    The outer product is formed inside the loop, so nothing the size of the
+    output is allocated for the inputs.
+    """
+    last = y_nodes.size - 2
+    outside = 0
+    for i in numba.prange(x.size):  # ty: ignore[not-iterable]
+        dx = x[i] - apex_x
+        for j in range(y.size):
+            dy = apex_y - y[j]
+            out_x[i, j] = np.arctan2(dx, dy) * slope + offset
+            scaled = (np.sqrt(dx * dx + dy * dy) - lo) * inv_h
+            k = int(scaled)
+            if k < 0:
+                k = 0
+                outside += 1
+            elif k > last:
+                k = last
+                outside += 1
+            below = y_nodes[k]
+            out_y[i, j] = below + (scaled - k) * (y_nodes[k + 1] - below)
+    return outside
+
+
+class ConicToCylindrical:
+    """Factored conic -> normal-cylindrical transform.
+
+    ``X = x_slope * theta + x_offset`` exactly; ``Y = interp(rho)`` from a table
+    dense enough for :data:`CONIC_TOLERANCE_METERS`.
+    """
+
+    __slots__ = ("apex_x", "apex_y", "inv_h", "rho_lo", "x_offset", "x_slope", "y_nodes")
+
+    def __init__(self, apex_x, apex_y, x_slope, x_offset, rho_lo, rho_hi, y_nodes):
+        self.apex_x = apex_x
+        self.apex_y = apex_y
+        self.x_slope = x_slope
+        self.x_offset = x_offset
+        self.rho_lo = rho_lo
+        self.inv_h = (y_nodes.size - 1) / (rho_hi - rho_lo)
+        self.y_nodes = y_nodes
+
+    def transform(
+        self, x: np.ndarray, y: np.ndarray, *, grid: bool = False
+    ) -> tuple[np.ndarray, np.ndarray] | None:
+        """Returns None when any rho falls outside the table, so callers fall back.
+
+        With ``grid``, 1D x and y are the axes of a rectilinear grid and the
+        output has shape ``(x.size, y.size)``. Otherwise x and y are matching
+        arrays of points. Two 1D arrays are ambiguous between the two, hence the
+        explicit flag.
+        """
+        x = np.asarray(x, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64)
+        rectilinear = grid and x.ndim == 1 and y.ndim == 1
+        shape = (x.size, y.size) if rectilinear else x.shape
+        out_x = np.empty(shape, dtype=np.float64)
+        out_y = np.empty(shape, dtype=np.float64)
+        kernel = _conic_kernel_1d if rectilinear else _conic_kernel
+        with NUMBA_THREADING_LOCK:
+            outside = kernel(
+                x,
+                y,
+                self.apex_x,
+                self.apex_y,
+                self.x_slope,
+                self.x_offset,
+                self.rho_lo,
+                self.inv_h,
+                self.y_nodes,
+                out_x,
+                out_y,
+            )
+        return None if outside else (out_x, out_y)
+
+
+def _cone_geometry(crs: CRS) -> tuple[float, float, float] | None:
+    """(apex_x, apex_y, n) in the CRS's own units, from its parameters.
+
+    Snyder's conic constants. The ellipsoid is always metric while the grid may
+    not be (US survey feet), hence the unit scaling.
+    """
+    with warnings.catch_warnings():
+        # to_dict() warns that a PROJ string loses information. We only read the
+        # conic parameters, which it keeps.
+        warnings.simplefilter("ignore", UserWarning)
+        params = crs.to_dict()
+    if params.get("proj") not in CONIC_PROJ_NAMES:
+        return None
+    ellipsoid = crs.ellipsoid
+    if ellipsoid is None or ellipsoid.semi_major_metre is None:
+        return None
+    unit = crs.axis_info[0].unit_conversion_factor
+    a = ellipsoid.semi_major_metre / unit
+    inverse_flattening = ellipsoid.inverse_flattening
+    f = 1.0 / inverse_flattening if inverse_flattening else 0.0
+    e = np.sqrt(2 * f - f * f)
+
+    lat_1 = params.get("lat_1", 0.0)
+    phi1 = np.deg2rad(lat_1)
+    phi2 = np.deg2rad(params.get("lat_2", lat_1))
+    phi0 = np.deg2rad(params.get("lat_0", 0.0))
+    x_0 = params.get("x_0", 0.0) / unit
+    y_0 = params.get("y_0", 0.0) / unit
+
+    def m(phi):
+        return np.cos(phi) / np.sqrt(1 - e * e * np.sin(phi) ** 2)
+
+    def q(phi):
+        s = np.sin(phi)
+        if e == 0:
+            return 2 * s
+        return (1 - e * e) * (
+            s / (1 - e * e * s * s) - np.log((1 - e * s) / (1 + e * s)) / (2 * e)
+        )
+
+    def t(phi):
+        s = np.sin(phi)
+        if e == 0:
+            return np.tan(np.pi / 4 - phi / 2)
+        return np.tan(np.pi / 4 - phi / 2) / ((1 - e * s) / (1 + e * s)) ** (e / 2)
+
+    tangent = abs(phi1 - phi2) < 1e-12
+    if params["proj"] == "aea":
+        n = (
+            np.sin(phi1)
+            if tangent
+            else (m(phi1) ** 2 - m(phi2) ** 2) / (q(phi2) - q(phi1))
+        )
+        if n == 0:
+            return None
+        rho0 = a * np.sqrt(m(phi1) ** 2 + n * q(phi1) - n * q(phi0)) / n
+    else:
+        n = (
+            np.sin(phi1)
+            if tangent
+            else (np.log(m(phi1)) - np.log(m(phi2))) / (np.log(t(phi1)) - np.log(t(phi2)))
+        )
+        if n == 0:
+            return None
+        rho0 = a * (m(phi1) / (n * t(phi1) ** n)) * t(phi0) ** n
+    if not np.isfinite(rho0):
+        return None
+    return x_0, y_0 + rho0, float(n)
+
+
+@lru_cache
+def conic_to_cylindrical(source_crs: CRS, target_crs: CRS) -> ConicToCylindrical | None:
+    """Build the factored transform, or None if the map does not factor.
+
+    The parameters give the cone geometry; only a numeric check tells us whether
+    the *composed* map really is a function of (rho, theta). It is not when the
+    datum step is position-dependent (e.g. BD72 -> WGS84 misses by metres), and
+    the parameters alone cannot show that.
+    """
+    geometry = _cone_geometry(source_crs)
+    if geometry is None:
+        return None
+    apex_x, apex_y, _ = geometry
+
+    to_source = transformer_from_crs(source_crs.geodetic_crs, source_crs)
+    to_target = transformer_from_crs(source_crs, target_crs)
+    lon, lat = _area_of_use_grid(source_crs, _CONIC_VALIDATION_SIDE)
+    sx, sy = to_source.transform(lon, lat)
+    tx, ty = to_target.transform(sx, sy)
+    finite = np.isfinite(sx) & np.isfinite(sy) & np.isfinite(tx) & np.isfinite(ty)
+    if finite.sum() < 4:
+        return None
+    sx, sy, tx, ty = sx[finite], sy[finite], tx[finite], ty[finite]
+
+    dx, dy = sx - apex_x, apex_y - sy
+    theta = np.arctan2(dx, dy)
+    rho = np.hypot(dx, dy)
+    x_slope, x_offset = np.polyfit(theta, tx, 1)
+
+    # The area of use is a lon/lat box, so a projected raster on this CRS reaches
+    # past it — its corners alone do. Pad generously, then clip back to where the
+    # target is finite (rho grows towards the far pole, where Web Mercator Y
+    # diverges). Anything still outside falls back to pyproj, so the margin is a
+    # performance choice, not a correctness one.
+    span = rho.max() - rho.min()
+    lo = max(rho.min() - _CONIC_RANGE_MARGIN * span, 0.0)
+    hi = rho.max() + _CONIC_RANGE_MARGIN * span
+    clipped = _finite_rho_range(to_target, apex_x, apex_y, lo, hi, rho.min(), rho.max())
+    if clipped is None:
+        return None
+    lo, hi = clipped
+
+    coarse = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, _CONIC_COARSE_NODES)
+    # Linear interpolation error is |Y''| h^2 / 8, so it falls as h^2. One coarse
+    # table sizes the final one.
+    curvature = np.abs(np.diff(coarse, 2)).max()
+    count = _CONIC_COARSE_NODES
+    if curvature > 0:
+        needed = _CONIC_COARSE_NODES * np.sqrt((curvature / 8) / CONIC_TOLERANCE_METERS)
+        count = int(np.clip(needed, _CONIC_COARSE_NODES, _CONIC_MAX_NODES))
+    y_nodes = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, count)
+    if not np.all(np.isfinite(y_nodes)):
+        return None
+
+    factored = ConicToCylindrical(
+        apex_x, apex_y, float(x_slope), float(x_offset), lo, hi, y_nodes
+    )
+    check = factored.transform(sx, sy)
+    if check is None:
+        return None
+    if max(np.abs(check[0] - tx).max(), np.abs(check[1] - ty).max()) > (
+        CONIC_TOLERANCE_METERS
+    ):
+        return None
+    return factored
+
+
+def _sample_y_of_rho(
+    to_target: pyproj.Transformer,
+    apex_x: float,
+    apex_y: float,
+    lo: float,
+    hi: float,
+    count: int,
+) -> np.ndarray:
+    """Y along the theta=0 ray, i.e. the central meridian, as a function of rho."""
+    rho = np.linspace(lo, hi, count)
+    _, y = to_target.transform(np.full_like(rho, apex_x), apex_y - rho)
+    return y
+
+
+def _finite_rho_range(
+    to_target: pyproj.Transformer,
+    apex_x: float,
+    apex_y: float,
+    lo: float,
+    hi: float,
+    must_cover_lo: float,
+    must_cover_hi: float,
+) -> tuple[float, float] | None:
+    """Shrink [lo, hi] to the finite run around the range we must cover."""
+    rho = np.linspace(lo, hi, _CONIC_COARSE_NODES)
+    y = _sample_y_of_rho(to_target, apex_x, apex_y, lo, hi, _CONIC_COARSE_NODES)
+    bad = np.flatnonzero(~np.isfinite(y))
+    if bad.size:
+        below = bad[rho[bad] < must_cover_lo]
+        above = bad[rho[bad] > must_cover_hi]
+        if below.size != bad.size - above.size:
+            return None  # a hole inside the range we need
+        lo = rho[below[-1] + 1] if below.size else lo
+        hi = rho[above[0] - 1] if above.size else hi
+    return (lo, hi) if hi > lo else None

--- a/src/xpublish_tiles/projections.py
+++ b/src/xpublish_tiles/projections.py
@@ -1,0 +1,131 @@
+"""Projection fastpaths: closed-form or factored replacements for pyproj.
+
+Everything here is pure numpy/pyproj on raw arrays. The xarray-aware,
+async orchestration lives in :mod:`xpublish_tiles.lib`.
+"""
+
+from functools import lru_cache, partial
+
+import numpy as np
+import pyproj
+from pyproj import CRS
+
+WGS84_SEMI_MAJOR_AXIS = np.float64(6378137.0)  # from proj
+M_PI = 3.14159265358979323846  # from proj
+M_2_PI = 6.28318530717958647693  # from proj
+
+# 4326 with order of axes reversed.
+OTHER_4326 = pyproj.CRS.from_user_input("WGS 84 (CRS84)")
+WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
+
+# https://pyproj4.github.io/pyproj/stable/advanced_examples.html#caching-pyproj-objects
+transformer_from_crs = lru_cache(partial(pyproj.Transformer.from_crs, always_xy=True))
+
+
+def is_degree_geographic(crs: CRS) -> bool:
+    """True for any geographic CRS with lon/lat axes in degrees (EPSG:4326,
+    CRS84, custom spherical datums like HEALPix's, etc.). The 4326-fastpath
+    in :func:`xpublish_tiles.lib.transform_coordinates` uses this to skip the
+    pyproj roundtrip and just wrap lon to [-180, 180], which is valid for all
+    such CRSes — any residual datum shift is sub-meter and below pixel
+    resolution.
+    """
+    return crs.is_geographic and all(ax.unit_name == "degree" for ax in crs.axis_info)
+
+
+# Below this, treating the source lon/lat as WGS84 lon/lat is sub-pixel at any
+# zoom we serve, so the numpy fastpaths may skip pyproj's datum step.
+MAX_DATUM_SHIFT_METERS = 1.0
+_PROBE_SIDE = 5
+
+
+@lru_cache
+def has_null_datum_shift(crs: CRS) -> bool:
+    """True when `crs` lon/lat may be treated as WGS84 lon/lat.
+
+    Probes the datum step over the CRS's area of use rather than pattern-matching
+    operation names: proj picks the operation per point, and a "null" one (e.g.
+    EPSG:1188 NAD83->WGS84) is indistinguishable from a ballpark fallback taken
+    because a shift grid is missing. Either way, what matters is the displacement.
+    """
+    lon, lat = _area_of_use_grid(crs, _PROBE_SIDE)
+    x, y = transformer_from_crs(crs, 4326).transform(lon, lat)
+    finite = np.isfinite(x) & np.isfinite(y)
+    if not finite.any():
+        return False
+    dlon = (x - lon)[finite]
+    dlon = (dlon + 180.0) % 360.0 - 180.0
+    shift = np.hypot(dlon * np.cos(np.deg2rad(lat[finite])), (y - lat)[finite]) * 111320
+    return bool(shift.max() < MAX_DATUM_SHIFT_METERS)
+
+
+def _area_of_use_grid(crs: CRS, side: int) -> tuple[np.ndarray, np.ndarray]:
+    """Flattened lon/lat sample grid covering the CRS's area of use."""
+    area = crs.area_of_use
+    west, south, east, north = (
+        (area.west, area.south, area.east, area.north)
+        if area is not None
+        else (-180.0, -85.0, 180.0, 85.0)
+    )
+    if east < west:
+        east += 360.0
+    lon, lat = np.meshgrid(np.linspace(west, east, side), np.linspace(south, north, side))
+    return lon.ravel(), lat.ravel()
+
+
+def epsg4326to3857(lon: np.ndarray, lat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    a = WGS84_SEMI_MAJOR_AXIS
+
+    x = np.asarray(lon, dtype=np.float64, copy=True)
+    y = np.asarray(lat, dtype=np.float64, copy=True)
+
+    # Only normalize longitude values that are outside the [-180, 180] range
+    # This preserves precision for values already in the valid range
+    # pyproj accepts both -180 and 180 as valid values without wrapping
+    needs_normalization = (x > 180) | (x < -180)
+
+    np.deg2rad(x, out=x)
+    if np.any(needs_normalization):
+        # Only normalize the values that need it to preserve precision
+        # doing it this way matches proj
+        x[needs_normalization] = ((x[needs_normalization] + M_PI) % (2 * M_PI)) - M_PI
+    # Clamp latitude to avoid infinity at poles in-place
+    # Web Mercator is only valid between ~85.05 degrees
+    # Given our padding, we may be sending in data at latitudes poleward of MAX_LAT
+    # MAX_LAT = 85.051128779806604  # atan(sinh(pi)) * 180 / pi
+    # np.clip(y, -MAX_LAT, MAX_LAT, out=y)
+
+    # Y coordinate: use more stable formula for large latitudes
+    # Using: y = a * asinh(tan(φ)) for better numerical stability
+    # following the proj formula
+    # https://github.com/OSGeo/PROJ/blob/ff43c46b19802f5953a1546b05f59c5b9ee65795/src/projections/merc.cpp#L14
+    # https://proj.org/en/stable/operations/projections/merc.html#forward-projection
+    # Note: WebMercator uses the "spherical form"
+    np.deg2rad(y, out=y)
+    np.tan(y, out=y)
+    np.arcsinh(y, out=y)
+
+    x *= a
+    y *= a
+
+    return x, y
+
+
+def aeqd_to_4326(
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    center_lat: float,
+    center_lon: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fast azimuthal equidistant (meters) to EPSG:4326 (degrees) conversion.
+
+    Uses flat-earth approximation. Accurate to 0.3% at 300km from center.
+    ~200x faster than pyproj for large arrays. Modifies x_m and y_m in place.
+    """
+    meters_per_deg_lat = 111320.0
+    meters_per_deg_lon = 111320.0 * np.cos(np.radians(center_lat))
+    x_m /= meters_per_deg_lon
+    x_m += center_lon
+    y_m /= meters_per_deg_lat
+    y_m += center_lat
+    return x_m, y_m

--- a/src/xpublish_tiles/render/raster.py
+++ b/src/xpublish_tiles/render/raster.py
@@ -25,10 +25,10 @@ from xpublish_tiles.types import (
     ImageFormat,
     RenderContext,
 )
-from xpublish_tiles.utils import NUMBA_THREADING_LOCK
+from xpublish_tiles.utils import NUMBA_PARALLEL, NUMBA_THREADING_LOCK
 
 
-@numba.njit(parallel=True, cache=True, boundscheck=False)
+@numba.njit(parallel=NUMBA_PARALLEL, nogil=True, cache=True, boundscheck=False)
 def _offdisk_quad_mask(xc, yc):
     """Mark cells whose quadmesh quad touches a non-finite (off-disk) vertex.
 
@@ -242,13 +242,12 @@ class DatashaderRasterRenderer(DatashaderRenderer):
                 data = maybe_cast_data(context.da)
                 if isinstance(grid, Geostationary):
                     xcoord, ycoord = data[grid.X], data[grid.Y]
-                    with NUMBA_THREADING_LOCK:
-                        # Transformation of points near the edge of the disk is undefined
-                        # and corrupts the rendering. Mask them out but only for
-                        # Geostationary to avoid the perf hit.
-                        bad = _offdisk_quad_mask(
-                            np.asarray(xcoord.data), np.asarray(ycoord.data)
-                        )
+                    # Transformation of points near the edge of the disk is undefined
+                    # and corrupts the rendering. Mask them out but only for
+                    # Geostationary to avoid the perf hit.
+                    bad = _offdisk_quad_mask(
+                        np.asarray(xcoord.data), np.asarray(ycoord.data)
+                    )
                     data = data.where(xr.DataArray(~bad, dims=xcoord.dims))
                 with log_duration(
                     f"render (continuous) {data.shape} quadmesh", "🎨", logger

--- a/src/xpublish_tiles/testing/datasets.py
+++ b/src/xpublish_tiles/testing/datasets.py
@@ -14,8 +14,8 @@ from pyproj.aoi import BBox
 import dask.array
 import xarray as xr
 from xarray import DataTree
-from xpublish_tiles.lib import transformer_from_crs
 from xpublish_tiles.multiscale import assign_leaf_xpublish_ids
+from xpublish_tiles.projections import transformer_from_crs
 from xpublish_tiles.testing.tiles import (
     ETRS89_TILES,
     ETRS89_TILES_EDGE_CASES,

--- a/src/xpublish_tiles/tiles_lib.py
+++ b/src/xpublish_tiles/tiles_lib.py
@@ -16,6 +16,8 @@ from xpublish_tiles.lib import (
     apply_default_pad,
     check_data_is_renderable_size,
     normalize_slicers,
+)
+from xpublish_tiles.projections import (
     transformer_from_crs,
 )
 from xpublish_tiles.utils import time_debug, xarray_object_key

--- a/src/xpublish_tiles/utils.py
+++ b/src/xpublish_tiles/utils.py
@@ -39,9 +39,11 @@ def _has_threadsafe_numba_layer() -> bool:
     return True
 
 
-NUMBA_THREADING_LOCK = (
-    contextlib.nullcontext() if _has_threadsafe_numba_layer() else threading.Lock()
-)
+# Our own parallel=True kernels are only worth it when they need no lock to run:
+# paying a process-wide lock to get ~4x on one array is a bad trade for a server
+# that is already parallel across requests.
+NUMBA_PARALLEL = _has_threadsafe_numba_layer()
+NUMBA_THREADING_LOCK = contextlib.nullcontext() if NUMBA_PARALLEL else threading.Lock()
 
 
 def cf_ref_attr(var: xr.DataArray, name: str) -> Any | None:

--- a/src/xpublish_tiles/xpublish/wms/utils.py
+++ b/src/xpublish_tiles/xpublish/wms/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import xarray as xr
 from xpublish_tiles.grids import guess_grid_system
-from xpublish_tiles.pipeline import transformer_from_crs
+from xpublish_tiles.projections import transformer_from_crs
 from xpublish_tiles.xpublish.wms.types import (
     WMSAttributeResponse,
     WMSBoundingBoxResponse,

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -54,13 +54,15 @@ from xpublish_tiles.lib import (
     cf_get,
     check_data_is_renderable_size,
     normalize_slicers,
-    transformer_from_crs,
 )
 from xpublish_tiles.pipeline import (
     apply_slicers,
     fix_coordinate_discontinuities,
     load_plans,
     pipeline,
+)
+from xpublish_tiles.projections import (
+    transformer_from_crs,
 )
 from xpublish_tiles.testing.datasets import (
     CUBED_SPHERE,

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -17,12 +17,14 @@ from xpublish_tiles.config import config
 from xpublish_tiles.lib import (
     apply_range_colors,
     coarsen_mean_pad,
-    epsg4326to3857,
     timedelta_to_iso8601,
     transform_chunk,
     transform_coordinates,
 )
 from xpublish_tiles.pipeline import _parse_timedelta
+from xpublish_tiles.projections import (
+    epsg4326to3857,
+)
 
 
 @given(

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -1,0 +1,109 @@
+import asyncio
+
+import numpy as np
+import pyproj
+import pytest
+
+import xarray as xr
+from xpublish_tiles.lib import transform_coordinates
+from xpublish_tiles.projections import (
+    CONIC_TOLERANCE_METERS,
+    conic_to_cylindrical,
+    has_null_datum_shift,
+    transformer_from_crs,
+)
+
+WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
+
+# (code, x range, y range) in the CRS's own units
+CONIC_EXTENTS = {
+    5070: ((-2.36e6, 2.26e6), (0.27e6, 3.17e6)),  # NAD83 / Conus Albers
+    3978: ((-2.4e6, 3.0e6), (-1.0e6, 3.5e6)),  # NAD83 / Canada Atlas Lambert
+    3005: ((0.2e6, 1.9e6), (0.35e6, 1.75e6)),  # NAD83 / BC Albers
+}
+
+
+@pytest.mark.parametrize("code", CONIC_EXTENTS)
+def test_conic_to_cylindrical_matches_pyproj(code):
+    factored = conic_to_cylindrical(pyproj.CRS.from_epsg(code), WEB_MERCATOR)
+    assert factored is not None
+
+    (x0, x1), (y0, y1) = CONIC_EXTENTS[code]
+    x = np.linspace(x0, x1, 401)
+    y = np.linspace(y1, y0, 397)
+    result = factored.transform(x, y, grid=True)
+    assert result is not None
+    out_x, out_y = result
+
+    grid_x, grid_y = np.meshgrid(x, y, indexing="ij")
+    expected_x, expected_y = transformer_from_crs(code, 3857).transform(grid_x, grid_y)
+    np.testing.assert_allclose(out_x, expected_x, atol=CONIC_TOLERANCE_METERS)
+    np.testing.assert_allclose(out_y, expected_y, atol=CONIC_TOLERANCE_METERS)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        32631,  # UTM: transverse aspect, no cone
+        2193,  # NZGD2000 / NZTM
+        3395,  # cylindrical: meridians never converge
+        31370,  # a real conic, but its datum shift is position-dependent
+    ],
+)
+def test_conic_to_cylindrical_rejects(code):
+    assert conic_to_cylindrical(pyproj.CRS.from_epsg(code), WEB_MERCATOR) is None
+
+
+def test_conic_to_cylindrical_rejects_rho_outside_table():
+    """Out of table range returns None so the caller falls back to pyproj."""
+    factored = conic_to_cylindrical(pyproj.CRS.from_epsg(5070), WEB_MERCATOR)
+    assert factored is not None
+    far = np.array([0.0])
+    assert factored.transform(far, np.array([-9e6]), grid=True) is None
+
+
+@pytest.mark.parametrize("curvilinear", [False, True])
+def test_transform_coordinates_conic(curvilinear):
+    crs = pyproj.CRS.from_epsg(5070)
+    (x0, x1), (y0, y1) = CONIC_EXTENTS[5070]
+    x = np.linspace(x0, x1, 301)
+    y = np.linspace(y1, y0, 293)
+    if curvilinear:
+        grid_x, grid_y = np.meshgrid(x, y)
+        subset = xr.DataArray(
+            np.zeros(grid_x.shape),
+            coords={"xc": (("j", "i"), grid_x), "yc": (("j", "i"), grid_y)},
+            dims=("j", "i"),
+        )
+        names = ("xc", "yc")
+    else:
+        subset = xr.DataArray(
+            np.zeros((y.size, x.size)), coords={"y": y, "x": x}, dims=("y", "x")
+        )
+        names = ("x", "y")
+
+    transformer = transformer_from_crs(crs, 3857)
+    out_x, out_y = asyncio.run(transform_coordinates(subset, *names, transformer))
+
+    src_x, src_y = xr.broadcast(subset[names[0]], subset[names[1]])
+    expected_x, expected_y = transformer.transform(src_x.data, src_y.data)
+    np.testing.assert_allclose(
+        out_x.transpose(*src_x.dims).data, expected_x, atol=CONIC_TOLERANCE_METERS
+    )
+    np.testing.assert_allclose(
+        out_y.transpose(*src_y.dims).data, expected_y, atol=CONIC_TOLERANCE_METERS
+    )
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        (4326, True),
+        (4269, True),  # NAD83 -> WGS84 is a registered null transformation
+        (4258, True),
+        (4267, False),  # NAD27 shifts by ~140m
+        (4277, False),  # OSGB36 shifts by ~115m
+    ],
+)
+def test_has_null_datum_shift(code, expected):
+    assert has_null_datum_shift(pyproj.CRS.from_epsg(code)) is expected

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 from xpublish_tiles.lib import transform_coordinates
 from xpublish_tiles.projections import (
+    CONIC_ALLOWLIST,
     CONIC_TOLERANCE_METERS,
     conic_to_cylindrical,
     has_null_datum_shift,
@@ -18,9 +19,42 @@ WEB_MERCATOR = pyproj.CRS.from_epsg(3857)
 # (code, x range, y range) in the CRS's own units
 CONIC_EXTENTS = {
     5070: ((-2.36e6, 2.26e6), (0.27e6, 3.17e6)),  # NAD83 / Conus Albers
-    3978: ((-2.4e6, 3.0e6), (-1.0e6, 3.5e6)),  # NAD83 / Canada Atlas Lambert
+    6350: ((-2.36e6, 2.26e6), (0.27e6, 3.17e6)),  # NAD83(2011) / Conus Albers
     3005: ((0.2e6, 1.9e6), (0.35e6, 1.75e6)),  # NAD83 / BC Albers
 }
+
+
+def test_every_allowlisted_crs_is_covered():
+    """Nothing goes on the allowlist without an extent to check it against."""
+    assert set(CONIC_EXTENTS) == CONIC_ALLOWLIST
+
+
+@pytest.mark.parametrize("code", CONIC_EXTENTS)
+def test_conic_map_factors(code):
+    """The allowlist asserts the composed map is a function of (rho, theta).
+
+    Nothing at runtime checks that any more, so check it here: sample the area of
+    use, and confirm the factored form reproduces pyproj everywhere on it.
+    """
+    src = pyproj.CRS.from_epsg(code)
+    factored = conic_to_cylindrical(src, WEB_MERCATOR)
+    assert factored is not None
+
+    area = src.area_of_use
+    assert area is not None
+    lon, lat = (
+        v.ravel()
+        for v in np.meshgrid(
+            np.linspace(area.west, area.east, 32),
+            np.linspace(area.south, area.north, 32),
+        )
+    )
+    x, y = transformer_from_crs(src.geodetic_crs, src).transform(lon, lat)
+    result = factored.transform(x, y)
+    assert result is not None
+    expected = transformer_from_crs(src, 3857).transform(x, y)
+    np.testing.assert_allclose(result[0], expected[0], atol=CONIC_TOLERANCE_METERS)
+    np.testing.assert_allclose(result[1], expected[1], atol=CONIC_TOLERANCE_METERS)
 
 
 @pytest.mark.parametrize("code", CONIC_EXTENTS)
@@ -31,7 +65,7 @@ def test_conic_to_cylindrical_matches_pyproj(code):
     (x0, x1), (y0, y1) = CONIC_EXTENTS[code]
     x = np.linspace(x0, x1, 401)
     y = np.linspace(y1, y0, 397)
-    result = factored.transform(x, y, grid=True)
+    result = factored.transform_grid(x, y)
     assert result is not None
     out_x, out_y = result
 
@@ -41,6 +75,27 @@ def test_conic_to_cylindrical_matches_pyproj(code):
     np.testing.assert_allclose(out_y, expected_y, atol=CONIC_TOLERANCE_METERS)
 
 
+def test_conic_matches_allowlist_without_epsg_code():
+    """A dataset carrying the same projection as a PROJ string still matches."""
+    proj4 = (
+        "+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 "
+        "+x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
+    )
+    crs = pyproj.CRS.from_proj4(proj4)
+    assert crs.area_of_use is None
+    factored = conic_to_cylindrical(crs, WEB_MERCATOR)
+    assert factored is not None
+
+    x = np.linspace(-2.36e6, 2.26e6, 401)
+    y = np.linspace(3.17e6, 0.27e6, 397)
+    result = factored.transform_grid(x, y)
+    assert result is not None
+    grid_x, grid_y = np.meshgrid(x, y, indexing="ij")
+    expected = transformer_from_crs(crs, 3857).transform(grid_x, grid_y)
+    np.testing.assert_allclose(result[0], expected[0], atol=CONIC_TOLERANCE_METERS)
+    np.testing.assert_allclose(result[1], expected[1], atol=CONIC_TOLERANCE_METERS)
+
+
 @pytest.mark.parametrize(
     "code",
     [
@@ -48,6 +103,7 @@ def test_conic_to_cylindrical_matches_pyproj(code):
         2193,  # NZGD2000 / NZTM
         3395,  # cylindrical: meridians never converge
         31370,  # a real conic, but its datum shift is position-dependent
+        3978,  # a real conic, but Arctic latitudes need an unaffordable table
     ],
 )
 def test_conic_to_cylindrical_rejects(code):
@@ -59,7 +115,7 @@ def test_conic_to_cylindrical_rejects_rho_outside_table():
     factored = conic_to_cylindrical(pyproj.CRS.from_epsg(5070), WEB_MERCATOR)
     assert factored is not None
     far = np.array([0.0])
-    assert factored.transform(far, np.array([-9e6]), grid=True) is None
+    assert factored.transform_grid(far, np.array([-9e6])) is None
 
 
 @pytest.mark.parametrize("curvilinear", [False, True])


### PR DESCRIPTION
Gate on the source being degree-geographic with a no-op datum step instead of
matching the 4326/CRS84 transformers exactly, so NAD83 and friends keep their
rectilinear coordinates. Detect the null datum shift by measuring the
displacement: proj chooses the operation per point, and a registered null
transformation looks the same as a ballpark fallback taken because a grid is
missing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>