### PR TITLE
Fix publishing distributions with metadata 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           hatch build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./dist
           print-hash: true


### PR DESCRIPTION
## Summary

- update `pypa/gh-action-pypi-publish` to v1.14.2
- use the immutable commit SHA required by repository policy
- enable publishing wheels and sdists containing Core Metadata 2.5

This fixes the 0.8.0 release failure in Actions run 32992385816. The previous action pin bundled Twine 6.1, while v1.14.2 bundles Twine 7 with Metadata 2.5 support.

## Validation

- `git diff --check`
- confirmed the pinned commit resolves to the v1.14.2 release