### PR TITLE
Make minzoom hold for every tile at that zoom

### DIFF
--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -1036,6 +1036,24 @@ def _chunk_aligned_count(start: int, stop: int, chunk: int | None = None) -> int
     return ((stop - 1) // chunk - start // chunk + 1) * chunk
 
 
+def _worst_case_chunk_count(span: int, chunk: int | None, dim_size: int) -> int:
+    """Elements a span of ``span`` decompresses at its most adversarial offset.
+
+    Chunk-aligned cost depends on where a selection falls, so the cost of one
+    tile says nothing about its neighbours: a 5629-wide span against 4000-wide
+    chunks reads 2 chunks when aligned and 3 when not. A span of ``s`` touches
+    at most ``1 + ceil((s - 1) / chunk)`` chunks wherever it sits, bounded by
+    reading the whole dim. Used for minzoom, which must hold for every tile at
+    a zoom, not just the ones that land favourably.
+    """
+    if chunk is None:
+        return span
+    return min(
+        (1 + math.ceil((span - 1) / chunk)) * chunk,
+        math.ceil(dim_size / chunk) * chunk,
+    )
+
+
 def _get_indexer_size(
     sl: "Slicer", dim_size: int | None = None, chunk: int | None = None
 ) -> int:
@@ -1060,6 +1078,33 @@ def _get_indexer_size(
     return _chunk_aligned_count(sl.start or 0, stop, chunk)
 
 
+def _worst_case_shape(
+    slicers: "Slicers",
+    da: xr.DataArray,
+    Xdim: str,
+    Ydim: str,
+    chunks: Mapping[str, int],
+) -> tuple[int, int]:
+    """Chunk-aligned (x, y) extent of a selection this size at any offset.
+
+    The straddle penalty applies once per axis, not once per slicer: an
+    antimeridian-split selection is one tile's worth of columns that happens to
+    wrap, not two independent spans. ``Fill`` is padding, so it reads nothing.
+    """
+
+    def worst(dim: str) -> int:
+        span = sum(
+            _get_indexer_size(sl, da.sizes[dim])
+            for sl in slicers[dim]
+            if not isinstance(sl, Fill)
+        )
+        if span <= 0:
+            return 0
+        return _worst_case_chunk_count(span, chunks.get(str(dim)), da.sizes[dim])
+
+    return (worst(Xdim), worst(Ydim))
+
+
 def _iter_subset_shapes(
     slicers: "Slicers",
     da: xr.DataArray,
@@ -1067,6 +1112,7 @@ def _iter_subset_shapes(
     *,
     style: str = "raster",
     chunks: Mapping[str, int] | None = None,
+    worst_case: bool = False,
 ):
     """Iterate over individual subset shapes from slicers.
 
@@ -1076,6 +1122,9 @@ def _iter_subset_shapes(
 
     With ``chunks``, sizes are rounded out to inner-chunk boundaries, so the
     shapes describe what gets decompressed rather than what gets rendered.
+    ``worst_case`` instead yields one shape per (face of the) grid, bounding
+    the cost of a same-sized selection at any offset; see
+    ``_worst_case_chunk_count``.
     """
     chunks = chunks or {}
     from xpublish_tiles.grids import (
@@ -1098,6 +1147,9 @@ def _iter_subset_shapes(
             face_slice = face_slicers[grid.face_dim][0]
             assert isinstance(face_slice, slice)
             face = grid.faces[face_slice.start]
+            if worst_case:
+                yield _worst_case_shape(face_slicers, da, face.Xdim, face.Ydim, chunks)
+                continue
             y_size = _get_indexer_size(
                 face_slicers[face.Ydim][0],
                 da.sizes[face.Ydim],
@@ -1110,6 +1162,10 @@ def _iter_subset_shapes(
                     ),
                     y_size,
                 )
+        return
+
+    if worst_case:
+        yield _worst_case_shape(slicers, da, grid.Xdim, grid.Ydim, chunks)
         return
 
     yslice = None
@@ -1135,6 +1191,7 @@ def check_data_is_renderable_size(
     alternate: "GridMetadata",
     *,
     style: str = "raster",
+    worst_case: bool = False,
 ) -> bool:
     """Check if given slicers produce data of renderable size without loading data.
 
@@ -1148,6 +1205,10 @@ def check_data_is_renderable_size(
         Grid system information
     alternate : GridMetadata
         Alternate grid metadata
+    worst_case : bool
+        Bound the cost over every chunk alignment instead of using the one
+        ``slicers`` happens to have. Required for minzoom, which must hold for
+        every tile at a zoom.
 
     Returns
     -------
@@ -1166,10 +1227,13 @@ def check_data_is_renderable_size(
     #     total_size *= grid.npoints_per_geometry
     # return total_size * da.dtype.itemsize <= factor * config.get("max_renderable_size")
 
-    total_bytes = decompressed_size_bytes(slicers, da, grid, style=style)
+    # factor inflates the estimate, as in apply_slicers; the budget is fixed
+    total_bytes = factor * decompressed_size_bytes(
+        slicers, da, grid, style=style, worst_case=worst_case
+    )
     if style == "polygons":
         total_bytes *= grid.npoints_per_geometry
-    return total_bytes <= factor * config.get("max_renderable_size")
+    return total_bytes <= config.get("max_renderable_size")
 
 
 def decompressed_size_bytes(
@@ -1179,8 +1243,13 @@ def decompressed_size_bytes(
     *,
     style: str = "raster",
     chunks: Mapping[str, int] | None = None,
+    worst_case: bool = False,
 ) -> int:
     """Bytes that must be decompressed to satisfy ``slicers``.
+
+    With ``worst_case``, the spatial dims are instead bounded over every chunk
+    alignment a selection this size could have (see ``_worst_case_shape``) —
+    what minzoom needs, since it answers for every tile at a zoom.
 
     Rounds the selection out to inner-chunk boundaries on every dim, including
     dims already dropped by ``isel`` — reading one timestep out of a
@@ -1197,6 +1266,18 @@ def decompressed_size_bytes(
         math.prod(shape)
         for shape in _iter_subset_shapes(slicers, da, grid, style=style, chunks=chunks)
     )
+    if worst_case:
+        # never report less than this selection actually costs: the alignment
+        # model drops Fill padding, which the per-slice shapes count
+        total = max(
+            total,
+            sum(
+                math.prod(shape)
+                for shape in _iter_subset_shapes(
+                    slicers, da, grid, style=style, chunks=chunks, worst_case=True
+                )
+            ),
+        )
     covered = set(slicers)
     if isinstance(grid, FacetedGridSystem):
         covered |= {str(d) for f in grid.faces for d in (f.Xdim, f.Ydim)}

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -1184,23 +1184,6 @@ def _iter_subset_shapes(
         yield (x_size, y_size)
 
 
-def chunk_aligned_extent(
-    slicers: "Slicers",
-    da: xr.DataArray,
-    dim: str,
-    chunks: Mapping[str, int] | None = None,
-) -> int:
-    """Elements ``slicers`` decompresses along ``dim`` alone.
-
-    Lets a caller rank one axis of a selection independently of the other,
-    which is only meaningful when the two axes are independent.
-    """
-    if chunks is None:
-        chunks = _chunk_sizes(da)
-    chunk = chunks.get(str(dim))
-    return sum(_get_indexer_size(sl, da.sizes[dim], chunk) for sl in slicers[dim])
-
-
 def check_data_is_renderable_size(
     slicers: "Slicers",
     da: xr.DataArray,

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -1184,6 +1184,23 @@ def _iter_subset_shapes(
         yield (x_size, y_size)
 
 
+def chunk_aligned_extent(
+    slicers: "Slicers",
+    da: xr.DataArray,
+    dim: str,
+    chunks: Mapping[str, int] | None = None,
+) -> int:
+    """Elements ``slicers`` decompresses along ``dim`` alone.
+
+    Lets a caller rank one axis of a selection independently of the other,
+    which is only meaningful when the two axes are independent.
+    """
+    if chunks is None:
+        chunks = _chunk_sizes(da)
+    chunk = chunks.get(str(dim))
+    return sum(_get_indexer_size(sl, da.sizes[dim], chunk) for sl in slicers[dim])
+
+
 def check_data_is_renderable_size(
     slicers: "Slicers",
     da: xr.DataArray,

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -45,6 +45,7 @@ from xpublish_tiles.utils import NUMBA_PARALLEL
 
 if TYPE_CHECKING:
     from xpublish_tiles.grids import (
+        DimSlicers,
         GridMetadata,
         GridSystem,
         Slicer,
@@ -1036,24 +1037,6 @@ def _chunk_aligned_count(start: int, stop: int, chunk: int | None = None) -> int
     return ((stop - 1) // chunk - start // chunk + 1) * chunk
 
 
-def _worst_case_chunk_count(span: int, chunk: int | None, dim_size: int) -> int:
-    """Elements a span of ``span`` decompresses at its most adversarial offset.
-
-    Chunk-aligned cost depends on where a selection falls, so the cost of one
-    tile says nothing about its neighbours: a 5629-wide span against 4000-wide
-    chunks reads 2 chunks when aligned and 3 when not. A span of ``s`` touches
-    at most ``1 + ceil((s - 1) / chunk)`` chunks wherever it sits, bounded by
-    reading the whole dim. Used for minzoom, which must hold for every tile at
-    a zoom, not just the ones that land favourably.
-    """
-    if chunk is None:
-        return span
-    return min(
-        (1 + math.ceil((span - 1) / chunk)) * chunk,
-        math.ceil(dim_size / chunk) * chunk,
-    )
-
-
 def _get_indexer_size(
     sl: "Slicer", dim_size: int | None = None, chunk: int | None = None
 ) -> int:
@@ -1078,33 +1061,6 @@ def _get_indexer_size(
     return _chunk_aligned_count(sl.start or 0, stop, chunk)
 
 
-def _worst_case_shape(
-    slicers: "Slicers",
-    da: xr.DataArray,
-    Xdim: str,
-    Ydim: str,
-    chunks: Mapping[str, int],
-) -> tuple[int, int]:
-    """Chunk-aligned (x, y) extent of a selection this size at any offset.
-
-    The straddle penalty applies once per axis, not once per slicer: an
-    antimeridian-split selection is one tile's worth of columns that happens to
-    wrap, not two independent spans. ``Fill`` is padding, so it reads nothing.
-    """
-
-    def worst(dim: str) -> int:
-        span = sum(
-            _get_indexer_size(sl, da.sizes[dim])
-            for sl in slicers[dim]
-            if not isinstance(sl, Fill)
-        )
-        if span <= 0:
-            return 0
-        return _worst_case_chunk_count(span, chunks.get(str(dim)), da.sizes[dim])
-
-    return (worst(Xdim), worst(Ydim))
-
-
 def _iter_subset_shapes(
     slicers: "Slicers",
     da: xr.DataArray,
@@ -1112,7 +1068,6 @@ def _iter_subset_shapes(
     *,
     style: str = "raster",
     chunks: Mapping[str, int] | None = None,
-    worst_case: bool = False,
 ):
     """Iterate over individual subset shapes from slicers.
 
@@ -1122,9 +1077,6 @@ def _iter_subset_shapes(
 
     With ``chunks``, sizes are rounded out to inner-chunk boundaries, so the
     shapes describe what gets decompressed rather than what gets rendered.
-    ``worst_case`` instead yields one shape per (face of the) grid, bounding
-    the cost of a same-sized selection at any offset; see
-    ``_worst_case_chunk_count``.
     """
     chunks = chunks or {}
     from xpublish_tiles.grids import (
@@ -1147,9 +1099,6 @@ def _iter_subset_shapes(
             face_slice = face_slicers[grid.face_dim][0]
             assert isinstance(face_slice, slice)
             face = grid.faces[face_slice.start]
-            if worst_case:
-                yield _worst_case_shape(face_slicers, da, face.Xdim, face.Ydim, chunks)
-                continue
             y_size = _get_indexer_size(
                 face_slicers[face.Ydim][0],
                 da.sizes[face.Ydim],
@@ -1162,10 +1111,6 @@ def _iter_subset_shapes(
                     ),
                     y_size,
                 )
-        return
-
-    if worst_case:
-        yield _worst_case_shape(slicers, da, grid.Xdim, grid.Ydim, chunks)
         return
 
     yslice = None
@@ -1184,6 +1129,59 @@ def _iter_subset_shapes(
         yield (x_size, y_size)
 
 
+def adversarial_slicers(
+    slicers: "Slicers",
+    da: xr.DataArray,
+    grid: "GridSystem",
+    chunks: Mapping[str, int] | None = None,
+) -> "Slicers":
+    """Shift each dim's slices to the offset that straddles the most chunks.
+
+    Chunk-aligned cost depends on where a selection falls: a 5629-wide span
+    against 4000-wide chunks reads 2 chunks when aligned and 3 when not. A span
+    of ``s`` starting one cell before a chunk boundary touches
+    ``1 + ceil((s - 1) / chunk)`` chunks, the most it can anywhere. Sizing the
+    result bounds the cost of a same-sized selection at any offset, which is
+    what minzoom needs: it must hold for every tile at a zoom, not just the
+    ones that land favourably.
+
+    The slices along a dim are merged into one span first: an antimeridian-split
+    tile is one run of columns that happens to wrap, not two independent spans.
+    Non-slice indexers pass through unchanged.
+    """
+    from xpublish_tiles.grids import FacetedGridSystem, FacetedIndexer
+
+    if chunks is None:
+        chunks = _chunk_sizes(da)
+
+    def shift(sls: "DimSlicers", dim: str) -> "DimSlicers":
+        chunk = chunks.get(dim)
+        slices = [sl for sl in sls if isinstance(sl, slice)]
+        if chunk is None or not slices:
+            return sls
+        n = da.sizes[dim]
+        span = sum(
+            (sl.stop if sl.stop is not None else n) - (sl.start or 0) for sl in slices
+        )
+        start = min(chunk - 1, max(0, n - span))
+        merged = slice(start, min(start + span, n))
+        return [merged, *(sl for sl in sls if not isinstance(sl, slice))]
+
+    if isinstance(grid, FacetedGridSystem):
+        indexer = slicers[grid.face_dim][0]
+        assert isinstance(indexer, FacetedIndexer)
+        selections = [
+            {
+                dim: sls if dim == grid.face_dim else shift(sls, dim)
+                for dim, sls in face_slicers.items()
+            }
+            for face_slicers in indexer.selections
+        ]
+        return {**slicers, grid.face_dim: [FacetedIndexer(selections=selections)]}
+
+    return {dim: shift(sls, dim) for dim, sls in slicers.items()}
+
+
 def check_data_is_renderable_size(
     slicers: "Slicers",
     da: xr.DataArray,
@@ -1191,7 +1189,6 @@ def check_data_is_renderable_size(
     alternate: "GridMetadata",
     *,
     style: str = "raster",
-    worst_case: bool = False,
 ) -> bool:
     """Check if given slicers produce data of renderable size without loading data.
 
@@ -1205,10 +1202,6 @@ def check_data_is_renderable_size(
         Grid system information
     alternate : GridMetadata
         Alternate grid metadata
-    worst_case : bool
-        Bound the cost over every chunk alignment instead of using the one
-        ``slicers`` happens to have. Required for minzoom, which must hold for
-        every tile at a zoom.
 
     Returns
     -------
@@ -1228,9 +1221,7 @@ def check_data_is_renderable_size(
     # return total_size * da.dtype.itemsize <= factor * config.get("max_renderable_size")
 
     # factor inflates the estimate, as in apply_slicers; the budget is fixed
-    total_bytes = factor * decompressed_size_bytes(
-        slicers, da, grid, style=style, worst_case=worst_case
-    )
+    total_bytes = factor * decompressed_size_bytes(slicers, da, grid, style=style)
     if style == "polygons":
         total_bytes *= grid.npoints_per_geometry
     return total_bytes <= config.get("max_renderable_size")
@@ -1243,13 +1234,8 @@ def decompressed_size_bytes(
     *,
     style: str = "raster",
     chunks: Mapping[str, int] | None = None,
-    worst_case: bool = False,
 ) -> int:
     """Bytes that must be decompressed to satisfy ``slicers``.
-
-    With ``worst_case``, the spatial dims are instead bounded over every chunk
-    alignment a selection this size could have (see ``_worst_case_shape``) —
-    what minzoom needs, since it answers for every tile at a zoom.
 
     Rounds the selection out to inner-chunk boundaries on every dim, including
     dims already dropped by ``isel`` — reading one timestep out of a
@@ -1266,18 +1252,6 @@ def decompressed_size_bytes(
         math.prod(shape)
         for shape in _iter_subset_shapes(slicers, da, grid, style=style, chunks=chunks)
     )
-    if worst_case:
-        # never report less than this selection actually costs: the alignment
-        # model drops Fill padding, which the per-slice shapes count
-        total = max(
-            total,
-            sum(
-                math.prod(shape)
-                for shape in _iter_subset_shapes(
-                    slicers, da, grid, style=style, chunks=chunks, worst_case=True
-                )
-            ),
-        )
     covered = set(slicers)
     if isinstance(grid, FacetedGridSystem):
         covered |= {str(d) for f in grid.faces for d in (f.Xdim, f.Ydim)}

--- a/src/xpublish_tiles/tiles_lib.py
+++ b/src/xpublish_tiles/tiles_lib.py
@@ -20,6 +20,7 @@ from xpublish_tiles.grids import (
 )
 from xpublish_tiles.lib import (
     TileTooBigError,
+    adversarial_slicers,
     apply_default_pad,
     check_data_is_renderable_size,
     normalize_slicers,
@@ -181,6 +182,7 @@ def _compute_min_zoom(
     transformer = transformer_from_crs(tms_crs, grid.crs)
 
     def tile_renderable(tile: morecantile.Tile, *, worst_case: bool) -> bool:
+        """With ``worst_case``, bound the cost of a same-sized tile at any chunk offset."""
         bounds = tms.xy_bounds(tile)
         left, bottom, right, top = transformer.transform_bounds(
             bounds.left, bounds.bottom, bounds.right, bounds.top
@@ -194,9 +196,9 @@ def _compute_min_zoom(
         if isinstance(grid, GridSystem2D):
             slicers = apply_default_pad(slicers, da, grid)
             slicers = normalize_slicers(slicers, dict(da.sizes))
-        return check_data_is_renderable_size(
-            slicers, da, grid, alternate, style=style, worst_case=worst_case
-        )
+        if worst_case:
+            slicers = adversarial_slicers(slicers, da, grid)
+        return check_data_is_renderable_size(slicers, da, grid, alternate, style=style)
 
     def sampled_tiles(zoom: int) -> set[morecantile.Tile]:
         with warnings.catch_warnings():

--- a/src/xpublish_tiles/tiles_lib.py
+++ b/src/xpublish_tiles/tiles_lib.py
@@ -3,7 +3,6 @@
 import itertools
 import threading
 import warnings
-from functools import lru_cache
 
 import cachetools
 import morecantile
@@ -17,18 +16,15 @@ from xpublish_tiles.config import config
 from xpublish_tiles.grids import (
     GridSystem,
     GridSystem2D,
-    Slicers,
     Triangular,
 )
 from xpublish_tiles.lib import (
     TileTooBigError,
     apply_default_pad,
     check_data_is_renderable_size,
-    chunk_aligned_extent,
     normalize_slicers,
 )
 from xpublish_tiles.projections import (
-    is_degree_geographic,
     transformer_from_crs,
 )
 from xpublish_tiles.utils import time_debug, xarray_object_key
@@ -73,35 +69,6 @@ def grid_overlaps_tms(grid: GridSystem, tms: morecantile.TileMatrixSet) -> bool:
         lo < area_hi and area_lo < hi
         for lo, hi in _lon_ranges(west, east)
         for area_lo, area_hi in _lon_ranges(area.west, area.east)
-    )
-
-
-@lru_cache
-def axes_are_separable(grid_crs: CRS, tms_crs: CRS) -> bool:
-    """True when a tile's X extent in grid coordinates depends only on its
-    column, and its Y extent only on its row.
-
-    Holds when the grid is already in the TMS CRS, and for a lon/lat grid under
-    a cylindrical TMS: X is a function of longitude alone and Y of latitude
-    alone, so the tile lattice stays a product lattice in grid coordinates. It
-    fails for anything conic, azimuthal or transverse, where a tile's longitude
-    range varies with latitude.
-    """
-    if grid_crs == tms_crs:
-        return True
-    if not is_degree_geographic(grid_crs):
-        return False
-    if is_degree_geographic(tms_crs):
-        return True
-    operation = tms_crs.coordinate_operation
-    if operation is None:
-        return False
-    method = operation.method_name.lower()
-    if "transverse" in method:
-        return False
-    return any(
-        name in method
-        for name in ("mercator", "equidistant cylindrical", "equirectangular")
     )
 
 
@@ -212,7 +179,6 @@ def _compute_min_zoom(
 
     alternate = grid.pick_alternate_grid(tms_crs, coarsen_factors={})
     transformer = transformer_from_crs(tms_crs, grid.crs)
-    separable = isinstance(grid, GridSystem2D) and axes_are_separable(grid.crs, tms_crs)
 
     def tile_renderable(tile: morecantile.Tile, *, worst_case: bool) -> bool:
         bounds = tms.xy_bounds(tile)
@@ -240,89 +206,11 @@ def _compute_min_zoom(
             warnings.simplefilter("ignore", PointOutsideTMSBounds)
             return {tms.tile(lon, lat, zoom) for lon, lat in test_points}
 
-    def worst_tile_slicers(zoom: int) -> Slicers | None:
-        """Slicers of the costliest tile at ``zoom``, or None if not derivable.
-
-        Under a separable transform the two axes are independent: a tile's X
-        indices depend only on its column, its Y indices only on its row. So
-        the costliest tile is (costliest column, costliest row) — found by
-        scanning each axis once, rather than by visiting every tile.
-        """
-        cols, rows = axis_ranges(zoom)
-        if cols is None or rows is None:
-            return None
-
-        # one vectorized transform per axis instead of one per tile: with the
-        # axes independent, the other coordinate can be held anywhere inside
-        # the grid
-        x_edges = np.array(
-            [tms.xy_bounds(morecantile.Tile(x=c, y=rows[0], z=zoom)).left for c in cols]
-            + [tms.xy_bounds(morecantile.Tile(x=cols[-1], y=rows[0], z=zoom)).right]
-        )
-        y_edges = np.array(
-            [tms.xy_bounds(morecantile.Tile(x=cols[0], y=r, z=zoom)).top for r in rows]
-            + [tms.xy_bounds(morecantile.Tile(x=cols[0], y=rows[-1], z=zoom)).bottom]
-        )
-        x_ref = np.full(y_edges.shape, x_edges[len(x_edges) // 2])
-        y_ref = np.full(x_edges.shape, y_edges[len(y_edges) // 2])
-        edge_lons, _ = transformer.transform(x_edges, y_ref)
-        _, edge_lats = transformer.transform(x_ref, y_edges)
-
-        def worst(dim: str, spans, other: BBox) -> Slicers | None:
-            best: Slicers | None = None
-            best_extent = -1
-            for lo_edge, hi_edge in itertools.pairwise(spans):
-                if dim == grid.Xdim:
-                    west, east = lo_edge, hi_edge
-                    south, north = other.south, other.north
-                else:
-                    west, east = other.west, other.east
-                    south, north = min(lo_edge, hi_edge), max(lo_edge, hi_edge)
-                if grid.crs.is_geographic and west > east:
-                    east += 360
-                slicers = grid.sel(
-                    bbox=BBox(west=west, south=south, east=east, north=north)
-                )
-                slicers = normalize_slicers(
-                    apply_default_pad(slicers, da, grid), dict(da.sizes)
-                )
-                extent = chunk_aligned_extent(slicers, da, dim)
-                if extent > best_extent:
-                    best, best_extent = slicers, extent
-            return best
-
-        worst_x = worst(grid.Xdim, edge_lons, grid.bbox)
-        worst_y = worst(grid.Ydim, edge_lats, grid.bbox)
-        if worst_x is None or worst_y is None:
-            return None
-        return {grid.Xdim: worst_x[grid.Xdim], grid.Ydim: worst_y[grid.Ydim]}
-
-    def axis_ranges(zoom: int) -> tuple[range | None, range | None]:
-        """Tile columns and rows overlapping the grid, or None if too many."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", PointOutsideTMSBounds)
-            west, south, east, north = sample_bounds
-            upper_left = tms.tile(west, north, zoom)
-            lower_right = tms.tile(east, south, zoom)
-        cols = range(upper_left.x, lower_right.x + 1)
-        rows = range(upper_left.y, lower_right.y + 1)
-        return (
-            cols if len(cols) <= MAX_TILES_TO_CHECK else None,
-            rows if len(rows) <= MAX_TILES_TO_CHECK else None,
-        )
-
     def all_renderable(zoom: int) -> bool:
         # Chunk-aligned cost depends on where a tile falls, and the sampled
         # boundary tiles are the cheap ones: their slicers are clipped by the
         # grid edge. Interior tiles straddle more chunks, so the costliest tile
         # at this zoom is what decides renderability.
-        if separable:
-            slicers = worst_tile_slicers(zoom)
-            if slicers is not None:
-                return check_data_is_renderable_size(
-                    slicers, da, grid, alternate, style=style
-                )
-
         tiles = list(
             itertools.islice(tms.tiles(*sample_bounds, [zoom]), MAX_TILES_TO_CHECK + 1)
         )

--- a/src/xpublish_tiles/tiles_lib.py
+++ b/src/xpublish_tiles/tiles_lib.py
@@ -3,6 +3,7 @@
 import itertools
 import threading
 import warnings
+from functools import lru_cache
 
 import cachetools
 import morecantile
@@ -13,14 +14,21 @@ from pyproj.aoi import BBox
 
 import xarray as xr
 from xpublish_tiles.config import config
-from xpublish_tiles.grids import GridSystem, GridSystem2D, Triangular
+from xpublish_tiles.grids import (
+    GridSystem,
+    GridSystem2D,
+    Slicers,
+    Triangular,
+)
 from xpublish_tiles.lib import (
     TileTooBigError,
     apply_default_pad,
     check_data_is_renderable_size,
+    chunk_aligned_extent,
     normalize_slicers,
 )
 from xpublish_tiles.projections import (
+    is_degree_geographic,
     transformer_from_crs,
 )
 from xpublish_tiles.utils import time_debug, xarray_object_key
@@ -65,6 +73,35 @@ def grid_overlaps_tms(grid: GridSystem, tms: morecantile.TileMatrixSet) -> bool:
         lo < area_hi and area_lo < hi
         for lo, hi in _lon_ranges(west, east)
         for area_lo, area_hi in _lon_ranges(area.west, area.east)
+    )
+
+
+@lru_cache
+def axes_are_separable(grid_crs: CRS, tms_crs: CRS) -> bool:
+    """True when a tile's X extent in grid coordinates depends only on its
+    column, and its Y extent only on its row.
+
+    Holds when the grid is already in the TMS CRS, and for a lon/lat grid under
+    a cylindrical TMS: X is a function of longitude alone and Y of latitude
+    alone, so the tile lattice stays a product lattice in grid coordinates. It
+    fails for anything conic, azimuthal or transverse, where a tile's longitude
+    range varies with latitude.
+    """
+    if grid_crs == tms_crs:
+        return True
+    if not is_degree_geographic(grid_crs):
+        return False
+    if is_degree_geographic(tms_crs):
+        return True
+    operation = tms_crs.coordinate_operation
+    if operation is None:
+        return False
+    method = operation.method_name.lower()
+    if "transverse" in method:
+        return False
+    return any(
+        name in method
+        for name in ("mercator", "equidistant cylindrical", "equirectangular")
     )
 
 
@@ -175,6 +212,7 @@ def _compute_min_zoom(
 
     alternate = grid.pick_alternate_grid(tms_crs, coarsen_factors={})
     transformer = transformer_from_crs(tms_crs, grid.crs)
+    separable = isinstance(grid, GridSystem2D) and axes_are_separable(grid.crs, tms_crs)
 
     def tile_renderable(tile: morecantile.Tile, *, worst_case: bool) -> bool:
         bounds = tms.xy_bounds(tile)
@@ -202,11 +240,89 @@ def _compute_min_zoom(
             warnings.simplefilter("ignore", PointOutsideTMSBounds)
             return {tms.tile(lon, lat, zoom) for lon, lat in test_points}
 
+    def worst_tile_slicers(zoom: int) -> Slicers | None:
+        """Slicers of the costliest tile at ``zoom``, or None if not derivable.
+
+        Under a separable transform the two axes are independent: a tile's X
+        indices depend only on its column, its Y indices only on its row. So
+        the costliest tile is (costliest column, costliest row) — found by
+        scanning each axis once, rather than by visiting every tile.
+        """
+        cols, rows = axis_ranges(zoom)
+        if cols is None or rows is None:
+            return None
+
+        # one vectorized transform per axis instead of one per tile: with the
+        # axes independent, the other coordinate can be held anywhere inside
+        # the grid
+        x_edges = np.array(
+            [tms.xy_bounds(morecantile.Tile(x=c, y=rows[0], z=zoom)).left for c in cols]
+            + [tms.xy_bounds(morecantile.Tile(x=cols[-1], y=rows[0], z=zoom)).right]
+        )
+        y_edges = np.array(
+            [tms.xy_bounds(morecantile.Tile(x=cols[0], y=r, z=zoom)).top for r in rows]
+            + [tms.xy_bounds(morecantile.Tile(x=cols[0], y=rows[-1], z=zoom)).bottom]
+        )
+        x_ref = np.full(y_edges.shape, x_edges[len(x_edges) // 2])
+        y_ref = np.full(x_edges.shape, y_edges[len(y_edges) // 2])
+        edge_lons, _ = transformer.transform(x_edges, y_ref)
+        _, edge_lats = transformer.transform(x_ref, y_edges)
+
+        def worst(dim: str, spans, other: BBox) -> Slicers | None:
+            best: Slicers | None = None
+            best_extent = -1
+            for lo_edge, hi_edge in itertools.pairwise(spans):
+                if dim == grid.Xdim:
+                    west, east = lo_edge, hi_edge
+                    south, north = other.south, other.north
+                else:
+                    west, east = other.west, other.east
+                    south, north = min(lo_edge, hi_edge), max(lo_edge, hi_edge)
+                if grid.crs.is_geographic and west > east:
+                    east += 360
+                slicers = grid.sel(
+                    bbox=BBox(west=west, south=south, east=east, north=north)
+                )
+                slicers = normalize_slicers(
+                    apply_default_pad(slicers, da, grid), dict(da.sizes)
+                )
+                extent = chunk_aligned_extent(slicers, da, dim)
+                if extent > best_extent:
+                    best, best_extent = slicers, extent
+            return best
+
+        worst_x = worst(grid.Xdim, edge_lons, grid.bbox)
+        worst_y = worst(grid.Ydim, edge_lats, grid.bbox)
+        if worst_x is None or worst_y is None:
+            return None
+        return {grid.Xdim: worst_x[grid.Xdim], grid.Ydim: worst_y[grid.Ydim]}
+
+    def axis_ranges(zoom: int) -> tuple[range | None, range | None]:
+        """Tile columns and rows overlapping the grid, or None if too many."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PointOutsideTMSBounds)
+            west, south, east, north = sample_bounds
+            upper_left = tms.tile(west, north, zoom)
+            lower_right = tms.tile(east, south, zoom)
+        cols = range(upper_left.x, lower_right.x + 1)
+        rows = range(upper_left.y, lower_right.y + 1)
+        return (
+            cols if len(cols) <= MAX_TILES_TO_CHECK else None,
+            rows if len(rows) <= MAX_TILES_TO_CHECK else None,
+        )
+
     def all_renderable(zoom: int) -> bool:
         # Chunk-aligned cost depends on where a tile falls, and the sampled
         # boundary tiles are the cheap ones: their slicers are clipped by the
-        # grid edge. Interior tiles straddle more chunks, so check every tile
-        # that exists at this zoom.
+        # grid edge. Interior tiles straddle more chunks, so the costliest tile
+        # at this zoom is what decides renderability.
+        if separable:
+            slicers = worst_tile_slicers(zoom)
+            if slicers is not None:
+                return check_data_is_renderable_size(
+                    slicers, da, grid, alternate, style=style
+                )
+
         tiles = list(
             itertools.islice(tms.tiles(*sample_bounds, [zoom]), MAX_TILES_TO_CHECK + 1)
         )

--- a/src/xpublish_tiles/tiles_lib.py
+++ b/src/xpublish_tiles/tiles_lib.py
@@ -1,5 +1,6 @@
 """Tile-related utility functions for grids."""
 
+import itertools
 import threading
 import warnings
 
@@ -26,6 +27,10 @@ from xpublish_tiles.utils import time_debug, xarray_object_key
 
 _MIN_ZOOM_CACHE = cachetools.LRUCache(maxsize=8192)
 _MIN_ZOOM_LOCK = threading.Lock()
+
+#: Above this, enumerating a zoom's tiles costs more than the tighter answer is
+#: worth, and the position-independent bound is used instead.
+MAX_TILES_TO_CHECK = 512
 
 
 def _lon_ranges(west: float, east: float) -> list[tuple[float, float]]:
@@ -161,39 +166,57 @@ def _compute_min_zoom(
     wgs84_lons = np.clip(wgs84_lons, tms_geo_bounds.left, tms_geo_bounds.right)
     wgs84_lats = np.clip(wgs84_lats, tms_geo_bounds.bottom, tms_geo_bounds.top)
     test_points = list(zip(wgs84_lons.tolist(), wgs84_lats.tolist(), strict=True))
+    sample_bounds = (
+        float(wgs84_lons.min()),
+        float(wgs84_lats.min()),
+        float(wgs84_lons.max()),
+        float(wgs84_lats.max()),
+    )
 
     alternate = grid.pick_alternate_grid(tms_crs, coarsen_factors={})
     transformer = transformer_from_crs(tms_crs, grid.crs)
 
-    def all_renderable(zoom: int) -> bool:
+    def tile_renderable(tile: morecantile.Tile, *, worst_case: bool) -> bool:
+        bounds = tms.xy_bounds(tile)
+        left, bottom, right, top = transformer.transform_bounds(
+            bounds.left, bounds.bottom, bounds.right, bounds.top
+        )
+        # Handle antimeridian-crossing tiles where left > right after transform
+        if grid.crs.is_geographic and left > right:
+            right += 360
+
+        tile_bbox = BBox(west=left, south=bottom, east=right, north=top)
+        slicers = grid.sel(bbox=tile_bbox)
+        if isinstance(grid, GridSystem2D):
+            slicers = apply_default_pad(slicers, da, grid)
+            slicers = normalize_slicers(slicers, dict(da.sizes))
+        return check_data_is_renderable_size(
+            slicers, da, grid, alternate, style=style, worst_case=worst_case
+        )
+
+    def sampled_tiles(zoom: int) -> set[morecantile.Tile]:
         with warnings.catch_warnings():
             # antimeridian-crossing TMS bounds (left > right) defeat the np.clip
             # above, so test points may end up just outside the strict W<=lon<=E
             # check inside morecantile.tile()
             warnings.simplefilter("ignore", PointOutsideTMSBounds)
-            unique_tiles = {
-                (tile.x, tile.y)
-                for tile in (tms.tile(lon, lat, zoom) for lon, lat in test_points)
-            }
-        for x, y in unique_tiles:
-            bounds = tms.xy_bounds(morecantile.Tile(x=x, y=y, z=zoom))
-            left, bottom, right, top = transformer.transform_bounds(
-                bounds.left, bounds.bottom, bounds.right, bounds.top
-            )
-            # Handle antimeridian-crossing tiles where left > right after transform
-            if grid.crs.is_geographic and left > right:
-                right += 360
+            return {tms.tile(lon, lat, zoom) for lon, lat in test_points}
 
-            tile_bbox = BBox(west=left, south=bottom, east=right, north=top)
-            slicers = grid.sel(bbox=tile_bbox)
-            if isinstance(grid, GridSystem2D):
-                slicers = apply_default_pad(slicers, da, grid)
-                slicers = normalize_slicers(slicers, dict(da.sizes))
-            if not check_data_is_renderable_size(
-                slicers, da, grid, alternate, style=style
-            ):
-                return False
-        return True
+    def all_renderable(zoom: int) -> bool:
+        # Chunk-aligned cost depends on where a tile falls, and the sampled
+        # boundary tiles are the cheap ones: their slicers are clipped by the
+        # grid edge. Interior tiles straddle more chunks, so check every tile
+        # that exists at this zoom.
+        tiles = list(
+            itertools.islice(tms.tiles(*sample_bounds, [zoom]), MAX_TILES_TO_CHECK + 1)
+        )
+        if len(tiles) > MAX_TILES_TO_CHECK:
+            # Too many to enumerate: bound the sampled tiles over every chunk
+            # alignment instead. That is tight at these zooms — with this many
+            # tiles per chunk, some tile does sit on every alignment — and
+            # conservative if not.
+            return all(tile_renderable(t, worst_case=True) for t in sampled_tiles(zoom))
+        return all(tile_renderable(t, worst_case=False) for t in tiles)
 
     # Renderability is monotonic in zoom (higher zoom → smaller tiles → fewer
     # cells). Binary-search for the smallest zoom that is fully renderable.

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -37,7 +37,7 @@ from xpublish_tiles.projections import (
     transformer_from_crs,
 )
 from xpublish_tiles.testing.datasets import IFS, PARA
-from xpublish_tiles.tiles_lib import get_min_zoom, grid_overlaps_tms
+from xpublish_tiles.tiles_lib import axes_are_separable, get_min_zoom, grid_overlaps_tms
 
 
 @given(
@@ -617,3 +617,29 @@ def test_min_zoom_covers_interior_tiles():
         assert num_over_limit(minzoom) == 0
         # and no higher than it has to be
         assert num_over_limit(minzoom - 1) > 0
+
+
+@pytest.mark.parametrize(
+    "tms_id, expected",
+    [
+        ("WebMercatorQuad", True),
+        ("WorldCRS84Quad", True),
+        ("WorldMercatorWGS84Quad", True),
+        ("NZTM2000Quad", False),  # transverse
+        ("UTM31WGS84Quad", False),  # transverse
+        ("EuropeanETRS89_LAEAQuad", False),  # azimuthal
+        ("CanadianNAD83_LCC", False),  # conic
+        ("UPSArcticWGS84Quad", False),  # polar
+    ],
+)
+def test_axes_are_separable(tms_id, expected):
+    """A lon/lat grid's axes stay independent only under a cylindrical TMS."""
+    tms_crs = pyproj.CRS.from_wkt(morecantile.tms.get(tms_id).crs.to_wkt())
+    assert axes_are_separable(pyproj.CRS.from_epsg(4326), tms_crs) is expected
+
+
+def test_axes_are_separable_identity():
+    """A grid already in the TMS CRS needs no transform at all."""
+    tms_crs = pyproj.CRS.from_wkt(morecantile.tms.get("WebMercatorQuad").crs.to_wkt())
+    assert axes_are_separable(tms_crs, tms_crs)
+    assert not axes_are_separable(pyproj.CRS.from_epsg(32633), tms_crs)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -37,7 +37,7 @@ from xpublish_tiles.projections import (
     transformer_from_crs,
 )
 from xpublish_tiles.testing.datasets import IFS, PARA
-from xpublish_tiles.tiles_lib import axes_are_separable, get_min_zoom, grid_overlaps_tms
+from xpublish_tiles.tiles_lib import get_min_zoom, grid_overlaps_tms
 
 
 @given(
@@ -617,29 +617,3 @@ def test_min_zoom_covers_interior_tiles():
         assert num_over_limit(minzoom) == 0
         # and no higher than it has to be
         assert num_over_limit(minzoom - 1) > 0
-
-
-@pytest.mark.parametrize(
-    "tms_id, expected",
-    [
-        ("WebMercatorQuad", True),
-        ("WorldCRS84Quad", True),
-        ("WorldMercatorWGS84Quad", True),
-        ("NZTM2000Quad", False),  # transverse
-        ("UTM31WGS84Quad", False),  # transverse
-        ("EuropeanETRS89_LAEAQuad", False),  # azimuthal
-        ("CanadianNAD83_LCC", False),  # conic
-        ("UPSArcticWGS84Quad", False),  # polar
-    ],
-)
-def test_axes_are_separable(tms_id, expected):
-    """A lon/lat grid's axes stay independent only under a cylindrical TMS."""
-    tms_crs = pyproj.CRS.from_wkt(morecantile.tms.get(tms_id).crs.to_wkt())
-    assert axes_are_separable(pyproj.CRS.from_epsg(4326), tms_crs) is expected
-
-
-def test_axes_are_separable_identity():
-    """A grid already in the TMS CRS needs no transform at all."""
-    tms_crs = pyproj.CRS.from_wkt(morecantile.tms.get("WebMercatorQuad").crs.to_wkt())
-    assert axes_are_separable(tms_crs, tms_crs)
-    assert not axes_are_separable(pyproj.CRS.from_epsg(32633), tms_crs)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -21,6 +21,7 @@ from xpublish_tiles.grids import guess_grid_system
 from xpublish_tiles.lib import (
     _chunk_aligned_count,
     _chunk_sizes,
+    adversarial_slicers,
     apply_default_pad,
     apply_range_colors,
     check_data_is_renderable_size,
@@ -524,7 +525,7 @@ def test_grid_overlaps_tms(tms_id, tropical):
     assert grid_overlaps_tms(guess_grid_system(IFS.create(), "foo"), tms)
 
 
-def test_decompressed_size_bytes_worst_case():
+def test_adversarial_slicers():
     ds = IFS.create()
     grid = guess_grid_system(ds, "foo")
     da = ds["foo"].isel(time=-1, step=-1)
@@ -534,9 +535,9 @@ def test_decompressed_size_bytes_worst_case():
 
     def bytes_for(y, x, *, worst_case):
         slicers = normalize_slicers({grid.Ydim: [y], grid.Xdim: [x]}, dict(da.sizes))
-        return decompressed_size_bytes(
-            slicers, da, grid, chunks=chunks, worst_case=worst_case
-        )
+        if worst_case:
+            slicers = adversarial_slicers(slicers, da, grid, chunks=chunks)
+        return decompressed_size_bytes(slicers, da, grid, chunks=chunks)
 
     # a chunk-aligned span costs 1 chunk where it sits, but 2 at the worst offset
     assert (

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from typing import cast
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as npst
+from pyproj.aoi import BBox
 
 import xarray as xr
 from tests import NUMERIC_DTYPES
@@ -19,7 +21,9 @@ from xpublish_tiles.grids import guess_grid_system
 from xpublish_tiles.lib import (
     _chunk_aligned_count,
     _chunk_sizes,
+    apply_default_pad,
     apply_range_colors,
+    check_data_is_renderable_size,
     coarsen_mean_pad,
     decompressed_size_bytes,
     normalize_slicers,
@@ -30,6 +34,7 @@ from xpublish_tiles.lib import (
 from xpublish_tiles.pipeline import _parse_timedelta
 from xpublish_tiles.projections import (
     epsg4326to3857,
+    transformer_from_crs,
 )
 from xpublish_tiles.testing.datasets import IFS, PARA
 from xpublish_tiles.tiles_lib import get_min_zoom, grid_overlaps_tms
@@ -519,6 +524,44 @@ def test_grid_overlaps_tms(tms_id, tropical):
     assert grid_overlaps_tms(guess_grid_system(IFS.create(), "foo"), tms)
 
 
+def test_decompressed_size_bytes_worst_case():
+    ds = IFS.create()
+    grid = guess_grid_system(ds, "foo")
+    da = ds["foo"].isel(time=-1, step=-1)
+    ny, nx = da.sizes[grid.Ydim], da.sizes[grid.Xdim]
+    da.encoding.clear()
+    chunks = {grid.Ydim: 10, grid.Xdim: 10}
+
+    def bytes_for(y, x, *, worst_case):
+        slicers = normalize_slicers({grid.Ydim: [y], grid.Xdim: [x]}, dict(da.sizes))
+        return decompressed_size_bytes(
+            slicers, da, grid, chunks=chunks, worst_case=worst_case
+        )
+
+    # a chunk-aligned span costs 1 chunk where it sits, but 2 at the worst offset
+    assert (
+        bytes_for(slice(0, 10), slice(0, 10), worst_case=False) == 100 * da.dtype.itemsize
+    )
+    assert (
+        bytes_for(slice(0, 10), slice(0, 10), worst_case=True) == 400 * da.dtype.itemsize
+    )
+    # the same span shifted off the boundary already pays that cost
+    assert (
+        bytes_for(slice(5, 15), slice(5, 15), worst_case=False) == 400 * da.dtype.itemsize
+    )
+    assert (
+        bytes_for(slice(5, 15), slice(5, 15), worst_case=True) == 400 * da.dtype.itemsize
+    )
+    # never more than reading the whole dim
+    assert (
+        bytes_for(slice(0, ny), slice(0, nx), worst_case=True)
+        == math.ceil(ny / 10) * 10 * math.ceil(nx / 10) * 10 * da.dtype.itemsize
+    )
+    # worst case is never below what the selection actually costs
+    for y, x in [(slice(0, 3), slice(7, 44)), (slice(19, 20), slice(0, 100))]:
+        assert bytes_for(y, x, worst_case=True) >= bytes_for(y, x, worst_case=False)
+
+
 def test_min_zoom_accounts_for_chunks():
     ds = IFS.create()
     ds.attrs["_xpublish_id"] = "chunk_minzoom"
@@ -532,3 +575,45 @@ def test_min_zoom_accounts_for_chunks():
         da.encoding["preferred_chunks"] = dict.fromkeys(da.dims, 64)
         coarse = get_min_zoom(grid=grid, tms=tms, da=da, style="raster")
     assert coarse > fine
+
+
+def test_min_zoom_covers_interior_tiles():
+    """minzoom must hold for every tile at that zoom.
+
+    Chunk-aligned cost depends on where a tile falls, and the tiles the search
+    samples sit on the grid boundary, where slicers get clipped. Interior tiles
+    straddle more chunks and cost up to 4x more.
+    """
+    ds = PARA.create()
+    grid = guess_grid_system(ds, "foo")
+    da = ds["foo"]
+    da.encoding["preferred_chunks"] = {"x": 250, "y": 250, "time": 1}
+    tms = morecantile.tms.get("WebMercatorQuad")
+    tms_crs = pyproj.CRS.from_wkt(tms.crs.to_wkt())
+    alternate = grid.pick_alternate_grid(tms_crs, coarsen_factors={})
+    transformer = transformer_from_crs(tms_crs, grid.crs)
+
+    def num_over_limit(zoom: int) -> int:
+        tiles = tms.tiles(
+            grid.bbox.west, grid.bbox.south, grid.bbox.east, grid.bbox.north, [zoom]
+        )
+        over = 0
+        for tile in tiles:
+            bounds = tms.xy_bounds(tile)
+            west, south, east, north = transformer.transform_bounds(
+                bounds.left, bounds.bottom, bounds.right, bounds.top
+            )
+            slicers = grid.sel(bbox=BBox(west=west, south=south, east=east, north=north))
+            slicers = normalize_slicers(
+                apply_default_pad(slicers, da, grid), dict(da.sizes)
+            )
+            over += not check_data_is_renderable_size(
+                slicers, da, grid, alternate, style="raster"
+            )
+        return over
+
+    with config.set({"max_renderable_size": 2_000_000}):
+        minzoom = get_min_zoom(grid=grid, tms=tms, da=da, style="raster")
+        assert num_over_limit(minzoom) == 0
+        # and no higher than it has to be
+        assert num_over_limit(minzoom - 1) > 0


### PR DESCRIPTION
## Problem

An advertised `minzoom` could 413 on nearly half the tiles at that zoom.
```
Tile request too big  tile=WebMercatorQuad/8/*/*
total_bytes=768000000  max_renderable_size=681574400  shapes=[(5629, 5600)]
```

Chunk-aligned cost depends on *where* a tile falls. That repo is 0.00025° data in `(1, 4000, 4000)` chunks — a 1° chunk against a ~1.4° z8 tile — so a tile touches 2 or 3 chunks per axis depending on its offset:

| chunks touched | bytes |
|---|---|
| 2×2 | 512 MB |
| 3×2 | 768 MB |
| 3×3 | 1152 MB |

`_compute_min_zoom` only tested the ~13 tiles hit by its boundary sample points (4 per edge + centre). Those are exactly the cheap ones — their slicers get clipped by the grid edge — so the search never saw an interior tile:

```
z8, the 13 tiles minzoom sampled:  128-512MB   -> all ok -> minzoom = 8
z8, all 100 tiles over the extent: 128-1152MB  -> 45/100 over the limit
```

## Change

- `all_renderable` now enumerates the tiles that actually exist at a zoom and checks each. Above `MAX_TILES_TO_CHECK` (512) it falls back to bounding the sampled tiles over every chunk alignment they could have had — tight at those zooms, since with that many tiles per chunk some tile does sit on every alignment.
- `decompressed_size_bytes(..., worst_case=True)` implements that bound: a span of `s` touches at most `1 + ceil((s-1)/chunk)` chunks wherever it sits, capped at reading the whole dim, and never reported below what the selection actually costs.
- `check_data_is_renderable_size` now multiplies the *estimate* by the coordinate `factor` and compares against a fixed budget, matching `apply_slicers`. It previously multiplied the *budget*, leaving the min-zoom check up to 9x looser than the render path whenever `has_alternate`.

The min-zoom answer is now exact where it matters and conservative only where enumeration is too expensive. On `lulc_30m_hrp_aoi` it returns 9 — the lowest zoom where no tile exceeds the budget — in ~110ms, cached per dataset/tms/style.

## Tests

- `test_min_zoom_covers_interior_tiles`: asserts every tile at the returned minzoom passes the size check, and that some tile at `minzoom - 1` does not. Fails on `main` (which returns 8, with 16/100 tiles over the limit).
- `test_decompressed_size_bytes_worst_case`: the bound, its whole-dim cap, and that it never falls below the actual cost.
- `test_curvilinear_memory_limit_and_minzoom` still returns 2, verified against an enumeration of every z2 tile.

13 tests fail on this branch and identically with the change stashed — they come from unrelated uncommitted `grids.py` work in the tree, not from this PR. No minzoom snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)