### PR TITLE
Pick the coarsest level that holds the variable for minzoom

### DIFF
--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Hashable
 from dataclasses import dataclass
 
 import morecantile
@@ -128,6 +129,14 @@ def get_coarsest_level(tree: DataTree) -> ResolutionLevel | None:
         return None
     # levels are sorted finest to coarsest, so last is coarsest
     return levels[-1]
+
+
+def get_coarsest_level_for(tree: DataTree, name: Hashable) -> ResolutionLevel | None:
+    """Coarsest level that holds ``name``. Overview levels may carry fewer variables than the finest."""
+    for level in reversed(scan_resolution_levels(tree)):
+        if name in level.dataset.data_vars:
+            return level
+    return None
 
 
 def get_resolution_level(

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from collections.abc import Hashable
 from typing import Any
 
 import morecantile.models
@@ -291,11 +292,13 @@ async def create_tileset_for_tms(
     var_grids: dict[str, GridSystem],
     *,
     cf_coords: dict | None = None,
+    minzoom_dataset: Dataset | None = None,
+    representative_var: Hashable | None = None,
 ) -> TilesetSummary | None:
     """Create a tileset summary for a specific tile matrix set
 
     Args:
-        dataset: xarray Dataset (coarsest level for multiscale datasets)
+        dataset: Finest-level xarray Dataset; it holds every variable in ``var_grids``
         tms_id: Tile matrix set identifier
         layer_extents: Pre-computed layer extents for all variables
         title: Dataset title
@@ -304,6 +307,10 @@ async def create_tileset_for_tms(
         dataset_attrs: Dataset attributes
         styles: Available styles
         var_grids: Renderable variable -> grid mapping (from ``detect_grids``)
+        minzoom_dataset: Coarsest level that holds ``representative_var``; drives the
+            tile matrix limits. Defaults to ``dataset``.
+        representative_var: Renderable variable present in ``minzoom_dataset``.
+            Defaults to the first key of ``var_grids``.
 
     Returns:
         TilesetSummary object if tile matrix set exists, None otherwise
@@ -357,8 +364,12 @@ async def create_tileset_for_tms(
     # ancillary variable whose grid can't be detected.
     tileMatrixSetLimits = await get_tile_matrix_limits(
         tms_id,
-        dataset,
-        representative_var=next(iter(var_grids)),
+        minzoom_dataset if minzoom_dataset is not None else dataset,
+        representative_var=(
+            representative_var
+            if representative_var is not None
+            else next(iter(var_grids))
+        ),
         cf_coords=cf_coords,
     )
 

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -35,7 +35,7 @@ from xpublish_tiles.logger import (
     with_accumulated_logs,
 )
 from xpublish_tiles.multiscale import (
-    get_coarsest_level,
+    get_coarsest_level_for,
     get_dataset,
     get_resolution_level,
 )
@@ -138,10 +138,6 @@ class TilesPlugin(Plugin):
             # If multiscale, returns finest (highest resolution) level available
             dataset = get_dataset(datatree)
 
-            # For multiscale datasets, get coarsest level for minzoom calculation
-            # Coarsest level determines the minimum zoom since it has fewer pixels
-            coarsest_level = get_coarsest_level(datatree)
-            minzoom_dataset = coarsest_level.dataset if coarsest_level else dataset
             # Get dataset metadata
             dataset_attrs = dataset.attrs
             title = dataset_attrs.get("title", "Dataset")
@@ -188,6 +184,12 @@ class TilesPlugin(Plugin):
                     detail="No renderable variables found in dataset.",
                 )
 
+            # For multiscale datasets, get coarsest level for minzoom calculation
+            # Coarsest level determines the minimum zoom since it has fewer pixels
+            representative_var = next(iter(var_grids))
+            coarsest_level = get_coarsest_level_for(datatree, representative_var)
+            minzoom_dataset = coarsest_level.dataset if coarsest_level else dataset
+
             # Create one tileset entry per supported tile matrix set
             supported_tms = get_all_tile_matrix_set_ids()
 
@@ -195,7 +197,7 @@ class TilesPlugin(Plugin):
             tileset_results = await asyncio.gather(
                 *[
                     create_tileset_for_tms(
-                        minzoom_dataset,
+                        dataset,
                         tms_id,
                         layer_extents,
                         title,
@@ -205,6 +207,8 @@ class TilesPlugin(Plugin):
                         styles,
                         var_grids,
                         cf_coords=cf_coords,
+                        minzoom_dataset=minzoom_dataset,
+                        representative_var=representative_var,
                     )
                     for tms_id in supported_tms
                 ]
@@ -478,7 +482,7 @@ class TilesPlugin(Plugin):
             # minzoom would be calculated from the finest level, preventing
             # low-zoom rendering even when overviews exist.
             var_name = query.variables[0]
-            coarsest_level = get_coarsest_level(datatree)
+            coarsest_level = get_coarsest_level_for(datatree, var_name)
             if coarsest_level is not None:
                 minzoom_dataset = coarsest_level.dataset
             else:

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -6,6 +6,7 @@ import xarray as xr
 from xarray import DataTree
 from xpublish_tiles.config import config
 from xpublish_tiles.multiscale import (
+    get_coarsest_level_for,
     get_crs,
     get_dataset,
     get_resolution_level,
@@ -358,3 +359,16 @@ def test_get_crs_falls_back_to_wkt2():
     result = get_crs(ds)
     assert result is not None
     assert result.to_epsg() == 4326
+
+
+def test_get_coarsest_level_for_prefers_the_coarsest_level_that_has_the_variable():
+    tree = GEOZARR_MULTISCALE.create()
+    finest = tree["0"].to_dataset()
+    finest["extra"] = finest["data"].copy()
+    tree["0"] = finest
+
+    coarsest_for_data = get_coarsest_level_for(tree, "data")
+    assert coarsest_for_data is not None and coarsest_for_data.path == "2"
+    coarsest_for_extra = get_coarsest_level_for(tree, "extra")
+    assert coarsest_for_extra is not None and coarsest_for_extra.path == "0"
+    assert get_coarsest_level_for(tree, "missing") is None

--- a/tests/test_xpublish/test_tiles/test_tiles_metadata.py
+++ b/tests/test_xpublish/test_tiles/test_tiles_metadata.py
@@ -969,3 +969,31 @@ def test_multiscale_uses_coarsest_level_for_minzoom():
     # Coarsest level (128x256 at 4 degrees/pixel) should give minzoom ~0
     # If we incorrectly used finest level (512x1024), minzoom would be ~2-3
     assert min_zoom <= 1, f"minzoom {min_zoom} too high - should use coarsest level"
+
+
+def test_multiscale_variable_missing_from_overviews_is_still_served():
+    """A variable that only the finest level carries must list and serve, and its
+    minzoom must come from the coarsest level that has it."""
+    tree = GEOZARR_MULTISCALE.create()
+    finest = tree["0"].to_dataset()
+    finest["extra"] = finest["data"].copy()
+    tree["0"] = finest
+
+    rest = xpublish.Rest({"pyramid": tree}, plugins={"tiles": TilesPlugin()})
+    client = TestClient(rest.app)
+
+    response = client.get("/datasets/pyramid/tiles/")
+    assert response.status_code == 200
+    tileset = next(
+        ts
+        for ts in response.json()["tilesets"]
+        if "WebMercatorQuad" in ts.get("tileMatrixSetURI", "")
+    )
+    assert {layer["id"] for layer in tileset["layers"]} == {"data", "extra"}
+
+    response = client.get(
+        "/datasets/pyramid/tiles/WebMercatorQuad/tilejson.json"
+        "?variables=extra&style=raster/viridis&width=256&height=256&colorscalerange=-1,1"
+    )
+    assert response.status_code == 200
+    assert response.json()["minzoom"] >= 0


### PR DESCRIPTION
## Summary

Overview levels of a multiscale dataset can carry fewer variables than the finest level. The tiles listing route detected variables on the finest level and then indexed the coarsest level with those names, so any variable missing from the coarsest level raised a bare `KeyError` out of xarray and the whole listing failed. The tilejson route asked the coarsest level for the requested variable and answered 404 "Invalid variable name(s)" for a variable that does exist.

`get_coarsest_level_for(tree, name)` walks the levels from coarsest to finest and returns the first one that holds the variable. The listing route now reads layer attributes from the finest level and computes tile matrix limits from the coarsest level that holds the representative variable. The tilejson route computes minzoom from the coarsest level that holds the requested variable. `create_tileset_for_tms` takes `minzoom_dataset` and `representative_var` as keyword arguments; both default to the old behavior.

Tests: a unit test for the helper, and a route test that adds a finest-only variable to the GeoZarr multiscale fixture and asserts the listing answers 200 with both layers and the tilejson for that variable answers 200. Before the change the listing raised `KeyError: "No variable named 'extra'..."` from `create_tileset_for_tms`.

## Context

The Arraylake tiles service saw 45 `KeyError` 500s in one week on the tiles listing route, all with xarray's "No variable named ..." message, from a customer's multiscale dataset whose overview levels do not carry every variable. The server only maps typed exceptions from this package to client errors, so the listing came back as an internal error. The variable names were not user input, so validating query parameters would not have helped; the fix is to read each level for the variables it actually holds.

[This is Claude Code on behalf of Samantha Hughes]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
