### PR TITLE
Compute minzoom per variable on the coarsest level that holds it

### DIFF
--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Hashable
 from dataclasses import dataclass
 
 import morecantile
@@ -117,17 +118,20 @@ def scan_resolution_levels(tree: DataTree) -> list[ResolutionLevel]:
     return levels
 
 
-def get_coarsest_level(tree: DataTree) -> ResolutionLevel | None:
+def get_coarsest_level(
+    tree: DataTree, name: Hashable | None = None
+) -> ResolutionLevel | None:
     """Get the coarsest (lowest resolution) level from a DataTree.
 
-    Used for calculating minzoom in tilejson - the coarsest overview
-    determines the lowest zoom level that can be rendered.
+    Used for calculating minzoom - the coarsest overview determines the
+    lowest zoom level that can be rendered. With ``name``, return the coarsest
+    level that holds that variable: overviews may carry fewer variables than
+    the finest level.
     """
-    levels = scan_resolution_levels(tree)
-    if not levels:
-        return None
-    # levels are sorted finest to coarsest, so last is coarsest
-    return levels[-1]
+    for level in reversed(scan_resolution_levels(tree)):
+        if name is None or name in level.dataset.data_vars:
+            return level
+    return None
 
 
 def get_resolution_level(

--- a/src/xpublish_tiles/multiscale.py
+++ b/src/xpublish_tiles/multiscale.py
@@ -118,6 +118,16 @@ def scan_resolution_levels(tree: DataTree) -> list[ResolutionLevel]:
     return levels
 
 
+def coarsest_level_holding(
+    levels: list[ResolutionLevel], name: Hashable | None = None
+) -> ResolutionLevel | None:
+    """Coarsest of ``levels`` (finest-first) that holds ``name``; any level if None."""
+    for level in reversed(levels):
+        if name is None or name in level.dataset.data_vars:
+            return level
+    return None
+
+
 def get_coarsest_level(
     tree: DataTree, name: Hashable | None = None
 ) -> ResolutionLevel | None:
@@ -128,10 +138,7 @@ def get_coarsest_level(
     level that holds that variable: overviews may carry fewer variables than
     the finest level.
     """
-    for level in reversed(scan_resolution_levels(tree)):
-        if name is None or name in level.dataset.data_vars:
-            return level
-    return None
+    return coarsest_level_holding(scan_resolution_levels(tree), name)
 
 
 def get_resolution_level(

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -21,6 +21,7 @@ from xpublish_tiles.xpublish.tiles.tile_matrix import (
     TILE_MATRIX_SET_SUMMARIES,
     TILE_MATRIX_SETS,
     extract_dimension_extents,
+    get_min_zooms,
     get_tile_matrix_limits,
 )
 from xpublish_tiles.xpublish.tiles.types import (
@@ -291,12 +292,14 @@ async def create_tileset_for_tms(
     styles: list[Style],
     var_grids: dict[str, GridSystem],
     *,
+    minzoom_datasets: dict[str, Dataset],
     cf_coords: dict | None = None,
 ) -> TilesetSummary | None:
     """Create a tileset summary for a specific tile matrix set
 
     Args:
-        dataset: xarray Dataset (coarsest level for multiscale datasets)
+        dataset: xarray Dataset holding every variable in ``var_grids`` (finest level
+            for multiscale datasets)
         tms_id: Tile matrix set identifier
         layer_extents: Pre-computed layer extents for all variables
         title: Dataset title
@@ -305,6 +308,8 @@ async def create_tileset_for_tms(
         dataset_attrs: Dataset attributes
         styles: Available styles
         var_grids: Renderable variable -> grid mapping (from ``detect_grids``)
+        minzoom_datasets: Variable -> dataset whose shape sets that variable's
+            minzoom (its coarsest overview for multiscale datasets)
 
     Returns:
         TilesetSummary object if tile matrix set exists, None otherwise
@@ -320,6 +325,10 @@ async def create_tileset_for_tms(
         return None
 
     tms_summary = TILE_MATRIX_SET_SUMMARIES[tms_id]()
+
+    # Each variable's minzoom comes from its own coarsest level; the tileset
+    # limits must hold for every layer, so they start at the largest one.
+    min_zooms = await get_min_zooms(tms_id, minzoom_datasets, cf_coords=cf_coords)
 
     # Create layers for each renderable data variable
     layers = []
@@ -358,16 +367,12 @@ async def create_tileset_for_tms(
                 ),
             ],
             extents=extents,
+            minTileMatrix=str(min_zooms[var_name]),
         )
         layers.append(layer)
 
-    # Pass a known-renderable variable so limits aren't computed from an
-    # ancillary variable whose grid can't be detected.
-    tileMatrixSetLimits = await get_tile_matrix_limits(
-        tms_id,
-        dataset,
-        representative_var=next(iter(var_grids)),
-        cf_coords=cf_coords,
+    tileMatrixSetLimits = get_tile_matrix_limits(
+        tms_id, range(max(min_zooms.values()), tms.maxzoom)
     )
 
     tileset = TilesetSummary(

--- a/src/xpublish_tiles/xpublish/tiles/metadata.py
+++ b/src/xpublish_tiles/xpublish/tiles/metadata.py
@@ -20,6 +20,7 @@ from xpublish_tiles.tiles_lib import grid_overlaps_tms
 from xpublish_tiles.xpublish.tiles.tile_matrix import (
     TILE_MATRIX_SET_SUMMARIES,
     TILE_MATRIX_SETS,
+    MinZoomSource,
     extract_dimension_extents,
     get_min_zooms,
     get_tile_matrix_limits,
@@ -292,7 +293,7 @@ async def create_tileset_for_tms(
     styles: list[Style],
     var_grids: dict[str, GridSystem],
     *,
-    minzoom_datasets: dict[str, Dataset],
+    minzoom_sources: dict[str, MinZoomSource],
     cf_coords: dict | None = None,
 ) -> TilesetSummary | None:
     """Create a tileset summary for a specific tile matrix set
@@ -308,8 +309,8 @@ async def create_tileset_for_tms(
         dataset_attrs: Dataset attributes
         styles: Available styles
         var_grids: Renderable variable -> grid mapping (from ``detect_grids``)
-        minzoom_datasets: Variable -> dataset whose shape sets that variable's
-            minzoom (its coarsest overview for multiscale datasets)
+        minzoom_sources: Variable -> grid and array that set its minzoom (from
+            its coarsest overview for multiscale datasets)
 
     Returns:
         TilesetSummary object if tile matrix set exists, None otherwise
@@ -328,7 +329,7 @@ async def create_tileset_for_tms(
 
     # Each variable's minzoom comes from its own coarsest level; the tileset
     # limits must hold for every layer, so they start at the largest one.
-    min_zooms = await get_min_zooms(tms_id, minzoom_datasets, cf_coords=cf_coords)
+    min_zooms = await get_min_zooms(tms_id, minzoom_sources)
 
     # Create layers for each renderable data variable
     layers = []

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -12,8 +12,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from xpublish import Dependencies, Plugin, hookimpl
 
-from xarray import Dataset, DataTree
+from xarray import DataTree
 from xpublish_tiles.grids import (
+    GridSystem,
     detect_grids,
     guess_grid_system,
 )
@@ -42,7 +43,11 @@ from xpublish_tiles.multiscale import (
 from xpublish_tiles.pipeline import _infer_datatype, pipeline
 from xpublish_tiles.tiles_lib import get_min_zoom, grid_overlaps_tms
 from xpublish_tiles.types import ImageFormat, LegendFormat, QueryParams
-from xpublish_tiles.utils import format_number_for_url, normalize_tilejson_bounds
+from xpublish_tiles.utils import (
+    format_number_for_url,
+    normalize_tilejson_bounds,
+    xarray_object_key,
+)
 from xpublish_tiles.xpublish.tiles.metadata import (
     create_tileset_for_tms,
     create_tileset_metadata,
@@ -53,6 +58,7 @@ from xpublish_tiles.xpublish.tiles.metadata import (
 from xpublish_tiles.xpublish.tiles.tile_matrix import (
     TILE_MATRIX_SET_SUMMARIES,
     TILE_MATRIX_SETS,
+    MinZoomSource,
     extract_tile_bbox_and_crs,
     get_all_tile_matrix_set_ids,
 )
@@ -186,10 +192,23 @@ class TilesPlugin(Plugin):
 
             # Overviews may carry fewer variables than the finest level, so each
             # variable's minzoom comes from the coarsest level that holds it.
-            minzoom_datasets: dict[str, Dataset] = {}
+            finest = get_resolution_level(datatree)
+            minzoom_sources: dict[str, MinZoomSource] = {}
+            coarse_grids: dict[tuple, GridSystem] = {}
             for var_name in layer_extents:
                 level = get_coarsest_level(datatree, var_name)
-                minzoom_datasets[var_name] = level.dataset if level else dataset
+                if level is None or (finest is not None and level.path == finest.path):
+                    minzoom_sources[var_name] = MinZoomSource(
+                        var_grids[var_name], dataset[var_name]
+                    )
+                    continue
+                da = level.dataset[var_name]
+                key = (level.path, xarray_object_key(da, cf_coords=cf_coords))
+                if key not in coarse_grids:
+                    coarse_grids[key] = await async_run(
+                        guess_grid_system, level.dataset, var_name, cf_coords=cf_coords
+                    )
+                minzoom_sources[var_name] = MinZoomSource(coarse_grids[key], da)
 
             # Create one tileset entry per supported tile matrix set
             supported_tms = get_all_tile_matrix_set_ids()
@@ -207,7 +226,7 @@ class TilesPlugin(Plugin):
                         dataset_attrs,
                         styles,
                         var_grids,
-                        minzoom_datasets=minzoom_datasets,
+                        minzoom_sources=minzoom_sources,
                         cf_coords=cf_coords,
                     )
                     for tms_id in supported_tms

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from xpublish import Dependencies, Plugin, hookimpl
 
-from xarray import DataTree
+from xarray import Dataset, DataTree
 from xpublish_tiles.grids import (
     detect_grids,
     guess_grid_system,
@@ -138,10 +138,6 @@ class TilesPlugin(Plugin):
             # If multiscale, returns finest (highest resolution) level available
             dataset = get_dataset(datatree)
 
-            # For multiscale datasets, get coarsest level for minzoom calculation
-            # Coarsest level determines the minimum zoom since it has fewer pixels
-            coarsest_level = get_coarsest_level(datatree)
-            minzoom_dataset = coarsest_level.dataset if coarsest_level else dataset
             # Get dataset metadata
             dataset_attrs = dataset.attrs
             title = dataset_attrs.get("title", "Dataset")
@@ -188,6 +184,13 @@ class TilesPlugin(Plugin):
                     detail="No renderable variables found in dataset.",
                 )
 
+            # Overviews may carry fewer variables than the finest level, so each
+            # variable's minzoom comes from the coarsest level that holds it.
+            minzoom_datasets: dict[str, Dataset] = {}
+            for var_name in layer_extents:
+                level = get_coarsest_level(datatree, var_name)
+                minzoom_datasets[var_name] = level.dataset if level else dataset
+
             # Create one tileset entry per supported tile matrix set
             supported_tms = get_all_tile_matrix_set_ids()
 
@@ -195,7 +198,7 @@ class TilesPlugin(Plugin):
             tileset_results = await asyncio.gather(
                 *[
                     create_tileset_for_tms(
-                        minzoom_dataset,
+                        dataset,
                         tms_id,
                         layer_extents,
                         title,
@@ -204,6 +207,7 @@ class TilesPlugin(Plugin):
                         dataset_attrs,
                         styles,
                         var_grids,
+                        minzoom_datasets=minzoom_datasets,
                         cf_coords=cf_coords,
                     )
                     for tms_id in supported_tms
@@ -478,7 +482,7 @@ class TilesPlugin(Plugin):
             # minzoom would be calculated from the finest level, preventing
             # low-zoom rendering even when overviews exist.
             var_name = query.variables[0]
-            coarsest_level = get_coarsest_level(datatree)
+            coarsest_level = get_coarsest_level(datatree, var_name)
             if coarsest_level is not None:
                 minzoom_dataset = coarsest_level.dataset
             else:
@@ -500,8 +504,8 @@ class TilesPlugin(Plugin):
                     ),
                 )
 
-            # Calculate min/max zoom based on data characteristics
-            xpublish_id = dataset.attrs.get("_xpublish_id")
+            # Cache under the level that was measured; levels share dim names.
+            xpublish_id = minzoom_dataset.attrs.get("_xpublish_id")
             minzoom = await async_run(
                 get_min_zoom,
                 grid=grid,

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -36,9 +36,11 @@ from xpublish_tiles.logger import (
     with_accumulated_logs,
 )
 from xpublish_tiles.multiscale import (
+    coarsest_level_holding,
     get_coarsest_level,
     get_dataset,
     get_resolution_level,
+    scan_resolution_levels,
 )
 from xpublish_tiles.pipeline import _infer_datatype, pipeline
 from xpublish_tiles.tiles_lib import get_min_zoom, grid_overlaps_tms
@@ -192,23 +194,29 @@ class TilesPlugin(Plugin):
 
             # Overviews may carry fewer variables than the finest level, so each
             # variable's minzoom comes from the coarsest level that holds it.
-            finest = get_resolution_level(datatree)
+            levels = scan_resolution_levels(datatree)
+            finest = levels[0] if levels else None
             minzoom_sources: dict[str, MinZoomSource] = {}
             coarse_grids: dict[tuple, GridSystem] = {}
             for var_name in layer_extents:
-                level = get_coarsest_level(datatree, var_name)
+                level = coarsest_level_holding(levels, var_name)
                 if level is None or (finest is not None and level.path == finest.path):
-                    minzoom_sources[var_name] = MinZoomSource(
-                        var_grids[var_name], dataset[var_name]
-                    )
-                    continue
-                da = level.dataset[var_name]
-                key = (level.path, xarray_object_key(da, cf_coords=cf_coords))
-                if key not in coarse_grids:
-                    coarse_grids[key] = await async_run(
-                        guess_grid_system, level.dataset, var_name, cf_coords=cf_coords
-                    )
-                minzoom_sources[var_name] = MinZoomSource(coarse_grids[key], da)
+                    level = None
+                source_ds = dataset if level is None else level.dataset
+                da = source_ds[var_name]
+                signature = xarray_object_key(da, cf_coords=cf_coords)
+                if level is None:
+                    grid = var_grids[var_name]
+                else:
+                    key = (level.path, signature)
+                    if key not in coarse_grids:
+                        coarse_grids[key] = await async_run(
+                            guess_grid_system, source_ds, var_name, cf_coords=cf_coords
+                        )
+                    grid = coarse_grids[key]
+                minzoom_sources[var_name] = MinZoomSource(
+                    grid, da, signature, source_ds.attrs.get("_xpublish_id")
+                )
 
             # Create one tileset entry per supported tile matrix set
             supported_tms = get_all_tile_matrix_set_ids()

--- a/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
+++ b/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
@@ -1,6 +1,7 @@
 """Tile matrix set definitions for OGC Tiles API"""
 
 from collections.abc import Hashable
+from dataclasses import dataclass
 from typing import cast
 
 import cf_xarray as cfxr  # noqa: F401 - needed to enable .cf accessor
@@ -12,7 +13,7 @@ import pyproj
 import pyproj.aoi
 
 import xarray as xr
-from xpublish_tiles.grids import guess_grid_system
+from xpublish_tiles.grids import GridSystem, guess_grid_system
 from xpublish_tiles.lib import async_run, timedelta_to_iso8601
 from xpublish_tiles.tiles_lib import get_min_zoom
 from xpublish_tiles.types import OutputBBox, OutputCRS
@@ -165,38 +166,34 @@ def extract_tile_bbox_and_crs(
     return output_bbox, OutputCRS(crs)
 
 
-async def get_min_zooms(
-    tms_id: str,
-    minzoom_datasets: dict[str, xr.Dataset],
-    *,
-    cf_coords: dict | None = None,
-) -> dict[str, int]:
-    """Minimum zoom per variable, each computed on the dataset that variable maps to.
+@dataclass
+class MinZoomSource:
+    """What minzoom needs from a variable: its grid, and an array for dims,
+    dtype and chunk layout. No data is read."""
 
-    Variables on the same dataset with the same spatial dims share one grid
-    detection and one min-zoom computation.
-    """
+    grid: GridSystem
+    da: xr.DataArray
+
+
+async def get_min_zooms(tms_id: str, sources: dict[str, MinZoomSource]) -> dict[str, int]:
+    """Minimum zoom per variable. Variables sharing a grid and spatial dims compute once."""
     tms = morecantile.tms.get(tms_id)
     groups: dict[tuple, list[str]] = {}
-    for var_name, ds in minzoom_datasets.items():
-        key = (id(ds), xarray_object_key(ds[var_name], cf_coords=cf_coords))
+    for var_name, source in sources.items():
+        key = (id(source.grid), xarray_object_key(source.da))
         groups.setdefault(key, []).append(var_name)
-
-    async def _min_zoom(var_name: str) -> int:
-        ds = minzoom_datasets[var_name]
-        grid = await async_run(guess_grid_system, ds, var_name, cf_coords=cf_coords)
-        return await async_run(
-            get_min_zoom,
-            grid=grid,
-            tms=tms,
-            da=ds[var_name],
-            style="raster",
-            xpublish_id=ds.attrs.get("_xpublish_id"),
-        )
 
     min_zooms: dict[str, int] = {}
     for names in groups.values():
-        zoom = await _min_zoom(names[0])
+        source = sources[names[0]]
+        zoom = await async_run(
+            get_min_zoom,
+            grid=source.grid,
+            tms=tms,
+            da=source.da,
+            style="raster",
+            xpublish_id=source.da.attrs.get("_xpublish_id"),
+        )
         min_zooms.update(dict.fromkeys(names, zoom))
     return min_zooms
 

--- a/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
+++ b/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
@@ -16,6 +16,7 @@ from xpublish_tiles.grids import guess_grid_system
 from xpublish_tiles.lib import async_run, timedelta_to_iso8601
 from xpublish_tiles.tiles_lib import get_min_zoom
 from xpublish_tiles.types import OutputBBox, OutputCRS
+from xpublish_tiles.utils import xarray_object_key
 from xpublish_tiles.xpublish.tiles.types import (
     DimensionExtent,
     DimensionType,
@@ -164,43 +165,45 @@ def extract_tile_bbox_and_crs(
     return output_bbox, OutputCRS(crs)
 
 
-async def get_tile_matrix_limits(
+async def get_min_zooms(
     tms_id: str,
-    dataset: xr.Dataset,
-    zoom_levels: range | None = None,
+    minzoom_datasets: dict[str, xr.Dataset],
     *,
-    representative_var: Hashable,
     cf_coords: dict | None = None,
-) -> list[TileMatrixSetLimit]:
-    """Generate tile matrix limits for the specified zoom levels based on dataset bounds.
+) -> dict[str, int]:
+    """Minimum zoom per variable, each computed on the dataset that variable maps to.
 
-    Args:
-        tms_id: Tile matrix set identifier
-        dataset: xarray Dataset to extract bounds from
-        representative_var: A renderable variable to detect the grid from.
-        zoom_levels: Range of zoom levels to generate limits for. If None, will be calculated
-                    from the Grid's min/max zoom levels.
-
-    Returns:
-        List of TileMatrixSetLimit objects
+    Variables on the same dataset with the same spatial dims share one grid
+    detection and one min-zoom computation.
     """
-    grid = await async_run(
-        guess_grid_system, dataset, representative_var, cf_coords=cf_coords
-    )
     tms = morecantile.tms.get(tms_id)
+    groups: dict[tuple, list[str]] = {}
+    for var_name, ds in minzoom_datasets.items():
+        key = (id(ds), xarray_object_key(ds[var_name], cf_coords=cf_coords))
+        groups.setdefault(key, []).append(var_name)
 
-    if zoom_levels is None:
-        xpublish_id = dataset.attrs.get("_xpublish_id")
-        min_zoom = await async_run(
+    async def _min_zoom(var_name: str) -> int:
+        ds = minzoom_datasets[var_name]
+        grid = await async_run(guess_grid_system, ds, var_name, cf_coords=cf_coords)
+        return await async_run(
             get_min_zoom,
             grid=grid,
             tms=tms,
-            da=dataset[representative_var],
+            da=ds[var_name],
             style="raster",
-            xpublish_id=xpublish_id,
+            xpublish_id=ds.attrs.get("_xpublish_id"),
         )
-        zoom_levels = range(min_zoom, tms.maxzoom)
 
+    min_zooms: dict[str, int] = {}
+    for names in groups.values():
+        zoom = await _min_zoom(names[0])
+        min_zooms.update(dict.fromkeys(names, zoom))
+    return min_zooms
+
+
+def get_tile_matrix_limits(tms_id: str, zoom_levels: range) -> list[TileMatrixSetLimit]:
+    """Full-extent tile matrix limits for each zoom level in ``zoom_levels``."""
+    tms = morecantile.tms.get(tms_id)
     limits = []
     for z in zoom_levels:
         minmax = tms.minmax(z)
@@ -213,7 +216,6 @@ async def get_tile_matrix_limits(
                 maxTileCol=minmax["y"]["max"],
             )
         )
-
     return limits
 
 

--- a/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
+++ b/src/xpublish_tiles/xpublish/tiles/tile_matrix.py
@@ -17,7 +17,6 @@ from xpublish_tiles.grids import GridSystem, guess_grid_system
 from xpublish_tiles.lib import async_run, timedelta_to_iso8601
 from xpublish_tiles.tiles_lib import get_min_zoom
 from xpublish_tiles.types import OutputBBox, OutputCRS
-from xpublish_tiles.utils import xarray_object_key
 from xpublish_tiles.xpublish.tiles.types import (
     DimensionExtent,
     DimensionType,
@@ -173,6 +172,10 @@ class MinZoomSource:
 
     grid: GridSystem
     da: xr.DataArray
+    # ``xarray_object_key(da)``, computed once by the caller (needs cf_coords)
+    signature: tuple
+    # the owning dataset's ``_xpublish_id``; the minzoom cache is keyed on it
+    xpublish_id: str | None
 
 
 async def get_min_zooms(tms_id: str, sources: dict[str, MinZoomSource]) -> dict[str, int]:
@@ -180,8 +183,7 @@ async def get_min_zooms(tms_id: str, sources: dict[str, MinZoomSource]) -> dict[
     tms = morecantile.tms.get(tms_id)
     groups: dict[tuple, list[str]] = {}
     for var_name, source in sources.items():
-        key = (id(source.grid), xarray_object_key(source.da))
-        groups.setdefault(key, []).append(var_name)
+        groups.setdefault((id(source.grid), source.signature), []).append(var_name)
 
     min_zooms: dict[str, int] = {}
     for names in groups.values():
@@ -192,7 +194,7 @@ async def get_min_zooms(tms_id: str, sources: dict[str, MinZoomSource]) -> dict[
             tms=tms,
             da=source.da,
             style="raster",
-            xpublish_id=source.da.attrs.get("_xpublish_id"),
+            xpublish_id=source.xpublish_id,
         )
         min_zooms.update(dict.fromkeys(names, zoom))
     return min_zooms

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -6,6 +6,7 @@ import xarray as xr
 from xarray import DataTree
 from xpublish_tiles.config import config
 from xpublish_tiles.multiscale import (
+    get_coarsest_level,
     get_crs,
     get_dataset,
     get_resolution_level,
@@ -358,3 +359,19 @@ def test_get_crs_falls_back_to_wkt2():
     result = get_crs(ds)
     assert result is not None
     assert result.to_epsg() == 4326
+
+
+def test_get_coarsest_level_for_variable():
+    tree = GEOZARR_MULTISCALE.create()
+    finest = tree["0"].to_dataset()
+    finest["extra"] = finest["data"].copy()
+    tree["0"] = finest
+
+    def path(name=None):
+        level = get_coarsest_level(tree, name)
+        return None if level is None else level.path
+
+    assert path() == "2"
+    assert path("data") == "2"
+    assert path("extra") == "0"
+    assert path("missing") is None

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[cubed_sphere].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[cubed_sphere].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -759,6 +760,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -1449,6 +1451,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2069,6 +2072,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2780,6 +2784,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3385,6 +3390,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4046,6 +4052,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4729,6 +4736,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5412,6 +5420,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "1",
           "title": "foo"
         }
       ],
@@ -6088,6 +6097,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -6764,6 +6774,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -7447,6 +7458,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -8123,6 +8135,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[era5].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[era5].json
@@ -35,6 +35,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -1235,6 +1236,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2393,6 +2395,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3481,6 +3484,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4660,6 +4664,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5733,6 +5738,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -6862,6 +6868,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -8013,6 +8020,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -9164,6 +9172,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "1",
           "title": "foo"
         }
       ],
@@ -10308,6 +10317,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -11452,6 +11462,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -12603,6 +12614,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -13747,6 +13759,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[fvcom].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[fvcom].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "eastward velocity"
         },
         {
@@ -51,6 +52,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "free surface"
         }
       ],
@@ -1243,6 +1245,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -1267,6 +1270,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],
@@ -2417,6 +2421,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -2441,6 +2446,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],
@@ -3612,6 +3618,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -3636,6 +3643,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],
@@ -4772,6 +4780,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -4796,6 +4805,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],
@@ -5939,6 +5949,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -5963,6 +5974,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],
@@ -7099,6 +7111,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "eastward velocity"
         },
         {
@@ -7123,6 +7136,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "free surface"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[geostationary].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[geostationary].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -1219,6 +1220,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2369,6 +2371,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3449,6 +3452,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4620,6 +4624,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5685,6 +5690,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -6828,6 +6834,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -7971,6 +7978,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "1",
           "title": "foo"
         }
       ],
@@ -9107,6 +9115,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -10243,6 +10252,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -11386,6 +11396,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -12522,6 +12533,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[geozarr_multiscale].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[geozarr_multiscale].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "data"
         }
       ],
@@ -1219,6 +1220,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -2299,6 +2301,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -3470,6 +3473,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -4606,6 +4610,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -5749,6 +5754,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -6885,6 +6891,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[global_healpix_l3].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[global_healpix_l3].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -759,6 +760,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -1449,6 +1451,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2069,6 +2072,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2780,6 +2784,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3385,6 +3390,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4046,6 +4052,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4729,6 +4736,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5412,6 +5420,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "1",
           "title": "foo"
         }
       ],
@@ -6088,6 +6097,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -6764,6 +6774,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -7447,6 +7458,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -8123,6 +8135,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[hrrr].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[hrrr].json
@@ -42,6 +42,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -1249,6 +1250,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2414,6 +2416,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3600,6 +3603,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4751,6 +4755,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5909,6 +5914,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -7060,6 +7066,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[ifs].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[ifs].json
@@ -43,6 +43,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -1251,6 +1252,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2417,6 +2419,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3513,6 +3516,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4700,6 +4704,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -5781,6 +5786,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -6918,6 +6924,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -8077,6 +8084,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -9236,6 +9244,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "1",
           "title": "foo"
         }
       ],
@@ -10388,6 +10397,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -11540,6 +11550,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -12699,6 +12710,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -13851,6 +13863,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[native_at_root_multiscale].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[native_at_root_multiscale].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "data"
         }
       ],
@@ -1219,6 +1220,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -2299,6 +2301,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -3470,6 +3473,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -4606,6 +4610,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -5749,6 +5754,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],
@@ -6885,6 +6891,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "data"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[radar].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[radar].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -759,6 +760,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -1449,6 +1451,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -2160,6 +2163,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -2836,6 +2840,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -3519,6 +3524,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],
@@ -4195,6 +4201,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "Equivalent reflectivity factor H"
         }
       ],

--- a/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[regional_healpix_na].json
+++ b/tests/test_xpublish/test_tiles/__snapshots__/test_tiles_metadata/test_tiles_endpoint_snapshot[regional_healpix_na].json
@@ -27,6 +27,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "-10",
           "title": "foo"
         }
       ],
@@ -759,6 +760,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -1449,6 +1451,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2160,6 +2163,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -2843,6 +2847,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -3519,6 +3524,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4202,6 +4208,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],
@@ -4878,6 +4885,7 @@
               "type": "image/png"
             }
           ],
+          "minTileMatrix": "0",
           "title": "foo"
         }
       ],

--- a/tests/test_xpublish/test_tiles/test_tiles_metadata.py
+++ b/tests/test_xpublish/test_tiles/test_tiles_metadata.py
@@ -9,6 +9,7 @@ from syrupy.extensions.json import JSONSnapshotExtension
 
 import xarray as xr
 from xarray.tests import raise_if_dask_computes
+from xpublish_tiles.config import config
 from xpublish_tiles.lib import VariableNotFoundError
 from xpublish_tiles.testing.datasets import (
     CUBED_SPHERE,
@@ -24,6 +25,7 @@ from xpublish_tiles.testing.datasets import (
     REGIONAL_HEALPIX_NA,
     UTM50S_HIRES,
 )
+from xpublish_tiles.tiles_lib import _MIN_ZOOM_CACHE
 from xpublish_tiles.xpublish.tiles import TilesPlugin
 from xpublish_tiles.xpublish.tiles.metadata import (
     _calculate_temporal_resolution,
@@ -969,3 +971,44 @@ def test_multiscale_uses_coarsest_level_for_minzoom():
     # Coarsest level (128x256 at 4 degrees/pixel) should give minzoom ~0
     # If we incorrectly used finest level (512x1024), minzoom would be ~2-3
     assert min_zoom <= 1, f"minzoom {min_zoom} too high - should use coarsest level"
+
+
+def test_multiscale_variable_missing_from_overviews():
+    """A finest-only variable lists and serves. Its minzoom comes from the finest
+    level; the tileset limits start at the largest per-layer minzoom."""
+    tree = GEOZARR_MULTISCALE.create()
+    finest = tree["0"].to_dataset()
+    finest["extra"] = finest["data"].copy()
+    finest["extra"].encoding["preferred_chunks"] = {"Y": 8, "X": 8}
+    tree["0"] = finest
+
+    rest = xpublish.Rest({"pyramid": tree}, plugins={"tiles": TilesPlugin()})
+    client = TestClient(rest.app)
+
+    # Budget holds the whole coarsest level (16x16 float32) but only part of the finest
+    _MIN_ZOOM_CACHE.clear()
+    with config.set(max_renderable_size=4 * 1024):
+        response = client.get("/datasets/pyramid/tiles/")
+        assert response.status_code == 200
+        tileset = next(
+            ts
+            for ts in response.json()["tilesets"]
+            if "WebMercatorQuad" in ts.get("tileMatrixSetURI", "")
+        )
+        layer_minzoom = {
+            layer["id"]: int(layer["minTileMatrix"]) for layer in tileset["layers"]
+        }
+        assert set(layer_minzoom) == {"data", "extra"}
+        assert layer_minzoom["extra"] > layer_minzoom["data"]
+        assert (
+            int(tileset["tileMatrixSetLimits"][0]["tileMatrix"]) == layer_minzoom["extra"]
+        )
+
+        for var, expected in layer_minzoom.items():
+            response = client.get(
+                "/datasets/pyramid/tiles/WebMercatorQuad/tilejson.json"
+                f"?variables={var}&style=raster/viridis&width=256&height=256&colorscalerange=-1,1"
+            )
+            assert response.status_code == 200
+            assert response.json()["minzoom"] == expected
+    _MIN_ZOOM_CACHE.clear()

--- a/tests/test_xpublish/test_tiles/test_tiles_plugin.py
+++ b/tests/test_xpublish/test_tiles/test_tiles_plugin.py
@@ -559,10 +559,7 @@ async def test_helper_functions(air_dataset):
     assert "WebMercatorQuad" in tms_ids
     assert len(tms_ids) >= 1
 
-    # Test tile matrix limits generation with dataset
-    limits = await get_tile_matrix_limits(
-        "WebMercatorQuad", air_dataset, range(3), representative_var="air"
-    )  # Just 0-2
+    limits = get_tile_matrix_limits("WebMercatorQuad", range(3))
     assert len(limits) == 3
     assert limits[0].tileMatrix == "0"
     assert limits[1].tileMatrix == "1"


### PR DESCRIPTION
Alternative to #282. Closes #269.

## Problem

Overview levels may carry fewer variables than the finest level. The `/tiles/` listing detected variables on the finest level and then indexed the coarsest level with those names, so a finest-only variable raised a bare `KeyError`. The tilejson route answered 404 for the same variable.

A single representative variable also cannot give correct tileset limits: a finest-only layer has a higher true minzoom than layers with overviews, so a client that trusts the tileset limits requests tiles that fail with `TileTooBigError`.

## Change

- `get_coarsest_level(tree, name)` returns the coarsest level that holds `name`.
- The listing computes minzoom per variable on that level. Each layer reports its own `minTileMatrix` (OGC 17-083r4, tile set metadata layer properties). The tileset `tileMatrixSetLimits` start at the largest per-layer minzoom so they hold for every layer.
- `MinZoomSource` (grid + lazy array) is what minzoom reads; `get_min_zooms` takes a mapping of these and computes once per grid and spatial dims. Grid detection on coarse levels runs once per (level, dims) in the plugin, not once per TMS as before. Single-level datasets reuse the `detect_grids` result and run no extra detection.
- `get_tile_matrix_limits` is now a pure function of `(tms_id, zoom_levels)`.
- The tilejson route caches minzoom under the id of the level it measured. It used the finest level's id, so multiscale levels with shared dim names collided in `_MIN_ZOOM_CACHE`.

Snapshots for `test_tiles_endpoint_snapshot` gain the `minTileMatrix` field only; no other values changed. The `-10` first tile matrix in those snapshots is pre-existing: CDB1GlobalGrid numbers its coarsest matrices from `-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
