### PR TITLE
Reject NaN/inf coordinates before unwrap_phase instead of hanging

### DIFF
--- a/src/xpublish_tiles/grids.py
+++ b/src/xpublish_tiles/grids.py
@@ -24,10 +24,12 @@ from xarray.core.indexing import IndexSelResult
 from xpublish_tiles.config import config
 from xpublish_tiles.lib import (
     Fill,
+    InvalidCoordinateValues,
     UnsupportedGridError,
     VariableNotFoundError,
     _coarsen_indices_impl,
     _prevent_slice_overlap,
+    anynotfinite,
     cf_get,
     crs_repr,
     fill_rings_from_corners,
@@ -2252,13 +2254,12 @@ class Curvilinear(GridSystem):
             # `CurvilinearCellIndex.sel` handles wrap with a 2-convention test.
             # Also skipped for regional grids with no seam — see
             # `_has_longitude_seam`.
-            if numbagg.anynan(X.data):
-                # The 2D `unwrap_phase` path degenerates into a non-terminating
-                # traversal when the array contains NaNs: NaN poisons its
-                # per-pixel reliability ordering. We have no NaN-safe unwrap yet.
-                raise UnsupportedGridError(
+            if anynotfinite(X.data):
+                # The 2D `unwrap_phase` path never terminates on NaN or inf: they
+                # poison its per-pixel reliability ordering. Masking does not help.
+                raise InvalidCoordinateValues(
                     "Cannot unwrap longitudes for a curvilinear grid that crosses "
-                    "the ±180°/360° seam and contains NaNs (e.g. a masked grid)."
+                    "the ±180°/360° seam and contains NaN/inf (e.g. a masked grid)."
                 )
             X = X.copy(data=unwrap(X.data, width=360))
             if corner_x is not None:

--- a/src/xpublish_tiles/lib.py
+++ b/src/xpublish_tiles/lib.py
@@ -55,6 +55,11 @@ if TYPE_CHECKING:
 from xpublish_tiles.logger import logger
 
 
+def anynotfinite(data: np.ndarray) -> bool:
+    """True if ``data`` holds any NaN or ±inf."""
+    return data.dtype.kind == "f" and not bool(np.isfinite(data).all())
+
+
 def unwrap(data: np.ndarray, *, width: float, axis: int | None = None) -> np.ndarray:
     """Remove ±width discontinuities from ``data``.
 
@@ -209,6 +214,12 @@ class VariableNotFoundError(Exception):
 class UnsupportedGridError(Exception):
     """Raised when no tileable grid system can be detected for a variable, or the
     detected grid is not supported."""
+
+    pass
+
+
+class InvalidCoordinateValues(Exception):
+    """Non-finite (NaN/inf) coordinates reached ``unwrap_phase``, which never terminates on them."""
 
     pass
 

--- a/src/xpublish_tiles/pipeline.py
+++ b/src/xpublish_tiles/pipeline.py
@@ -36,12 +36,14 @@ from xpublish_tiles.lib import (
     AsyncLoadTimeoutError,
     CoarsenedCoordinateIndices,
     IndexingError,
+    InvalidCoordinateValues,
     MissingParameterError,
     PadDimension,
     TileTooBigError,
     VariableNotFoundError,
     _chunk_sizes,
     _iter_subset_shapes,
+    anynotfinite,
     apply_default_pad,
     async_run,
     coarsen_mean_pad,
@@ -691,6 +693,14 @@ def fix_coordinate_discontinuities(
         # it's area of use is (-35.58, 24.6, 44.83, 84.73)
         # we ignore such things for now
         return coordinates
+
+    if anynotfinite(coordinates):
+        # `unwrap_phase` (axis=None) hangs on NaN/inf, e.g. HYCOM/RTOFS fold-row
+        # longitudes past 360° that Web Mercator maps to inf.
+        raise InvalidCoordinateValues(
+            "Cannot fix coordinate discontinuities for a coordinate array "
+            "containing NaN/inf after projection."
+        )
 
     # Step 1: Use unwrap to fix discontinuities
     unwrapped_coords = unwrap(coordinates, width=coordinate_space_width, axis=axis)

--- a/src/xpublish_tiles/testing/datasets.py
+++ b/src/xpublish_tiles/testing/datasets.py
@@ -1133,6 +1133,72 @@ TRIPOLE_ANTIMERIDIAN = Dataset(
 )
 
 
+def tripolar_global_unwrapped_grid(
+    *,
+    dims: tuple[Dim, ...],
+    dtype: npt.DTypeLike,
+    attrs: dict[str, Any],
+) -> xr.Dataset:
+    """Global tripolar grid with unwrapped lons, modelled on RTOFS/HYCOM GLBb.
+
+    Lons run continuously from 74°E past 360°; the fold row carries the
+    whole-wrap offsets HYCOM ships, so Web Mercator maps part of it to inf.
+    """
+    ds = uniform_grid(dims=dims, dtype=dtype, attrs=attrs)
+
+    y_dim, x_dim = dims[0], dims[1]
+    ny, nx = y_dim.size, x_dim.size
+
+    # Real RTOFS is Mercator-like up to ~47°N (row 2172 of 3298) and a
+    # curvilinear bipolar cap above it; `cap` ramps 0→1 across that boundary.
+    x_frac = np.linspace(0.0, 1.0, nx)
+    y_frac = np.linspace(0.0, 1.0, ny)
+    cap_start = 2172 / 3298
+    cap = np.clip((y_frac - cap_start) / (1.0 - cap_start), 0.0, 1.0) ** 2
+
+    # --- Longitude: exactly one wrap, left unwrapped, starting at 74.12°E ---
+    # `sin(2 pi x)` puts the cap's two lobes interior and pins x=0 and x=1, so
+    # every row spans precisely 360°. Amplitude 87° matches the peak deviation
+    # from linear measured on the real top row.
+    lobes = np.sin(2.0 * np.pi * x_frac)
+    lons = (74.12 + x_frac * 360.0)[None, :] + 87.0 * cap[:, None] * lobes[None, :]
+    lons = lons.astype(np.float32)
+
+    # --- Latitude: Southern Ocean to 47°N, then two poles in the cap ---
+    # Below the cap latitude is X-independent; inside it the lobes rise to
+    # 89.98°N while the X edges stay pinned at the cap-start latitude, as in
+    # RTOFS (``lat[3296]`` is 47.042 at columns 0, mid and -1, 89.978 at peak).
+    lat_col = np.linspace(-78.64, 47.04, ny)
+    lats = np.broadcast_to(lat_col[:, None], (ny, nx)).astype(np.float64).copy()
+    lats += (89.98 - 47.04) * cap[:, None] * np.abs(lobes)[None, :]
+    lats = lats.astype(np.float32)
+
+    # --- Tripolar fold seam: top row is the row below it, reversed, carrying
+    # the whole-wrap offsets HYCOM ships (measured on real RTOFS as
+    # {-360, 0, +360, +720}).
+    lons[-1] = (
+        np.flip(lons[-2]) + np.resize(np.array([-360.0, 0.0, 360.0, 720.0]), nx)
+    ).astype(np.float32)
+    lats[-1] = np.flip(lats[-2])
+
+    ds.coords["lat"] = ((y_dim.name, x_dim.name), lats, {"standard_name": "latitude"})
+    ds.coords["lon"] = ((y_dim.name, x_dim.name), lons, {"standard_name": "longitude"})
+    ds["foo"].attrs["coordinates"] = "lat lon"
+
+    return ds
+
+
+TRIPOLE_GLOBAL_UNWRAPPED = Dataset(
+    name="tripole_global_unwrapped",
+    dims=(
+        Dim(name="Y", size=400, chunk_size=200, data=None),
+        Dim(name="X", size=800, chunk_size=400, data=None),
+    ),
+    dtype=np.float32,
+    setup=tripolar_global_unwrapped_grid,
+)
+
+
 def cubed_sphere_grid(
     *,
     dims: tuple[Dim, ...],
@@ -2386,6 +2452,7 @@ DATASET_LOOKUP = {
     "fvcom_machias_bay": FVCOM_MACHIAS_BAY,
     "ugrid_triangles": UGRID_TRIANGLES,
     "tripole_antimeridian": TRIPOLE_ANTIMERIDIAN,
+    "tripole_global_unwrapped": TRIPOLE_GLOBAL_UNWRAPPED,
     "cubed_sphere": CUBED_SPHERE,
     "geostationary": GEOSTATIONARY,
     "global_healpix_l3": GLOBAL_HEALPIX_L3,

--- a/src/xpublish_tiles/xpublish/tiles/plugin.py
+++ b/src/xpublish_tiles/xpublish/tiles/plugin.py
@@ -21,6 +21,7 @@ from xpublish_tiles.lib import (
     AsyncLoadTimeoutError,
     ColormapError,
     IndexingError,
+    InvalidCoordinateValues,
     MissingParameterError,
     TileTooBigError,
     UnsupportedGridError,
@@ -634,6 +635,11 @@ class TilesPlugin(Plugin):
                 bound_logger.error("MissingParameterError", exc_info=e)
                 status_code = 422
                 detail = f"Missing parameter: {e!s}."
+            except InvalidCoordinateValues as e:
+                bound_logger = get_context_logger()
+                bound_logger.error("InvalidCoordinateValues", exc_info=e)
+                status_code = 422
+                detail = f"Cannot render this grid: {e!s}"
             except ColormapError as e:
                 bound_logger = get_context_logger()
                 bound_logger.error("ColormapError", exc_info=e)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -46,6 +46,7 @@ from xpublish_tiles.grids import (
     match_coord_dim,
 )
 from xpublish_tiles.lib import (
+    InvalidCoordinateValues,
     TileTooBigError,
     UnsupportedGridError,
     VariableNotFoundError,
@@ -1582,6 +1583,30 @@ def test_detect_orca_tripole_fold_row() -> None:
     (index,) = grid.indexes
     assert isinstance(index, CurvilinearCellIndex)
     assert index.tripolar_fold_row == ny - 1
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_curvilinear_seam_rejects_nonfinite_lons(bad) -> None:
+    """Seam-crossing curvilinear grids hit the 2D ``unwrap_phase``, which hangs on NaN or inf."""
+    ny, nx = 8, 8
+    # Lons 100°E -> 100°W across the antimeridian so `_has_longitude_seam` fires.
+    row = (((np.linspace(100.0, 260.0, nx) + 180.0) % 360.0) - 180.0).astype(np.float32)
+    lons2d = np.broadcast_to(row[None, :], (ny, nx)).astype(np.float32).copy()
+    lons2d[0, 0] = bad
+    lats2d = np.broadcast_to(
+        np.linspace(-80.0, 80.0, ny, dtype=np.float32)[:, None], (ny, nx)
+    ).astype(np.float32)
+
+    ds = xr.Dataset(
+        {"foo": (("j", "i"), np.zeros((ny, nx), dtype=np.float32))},
+        coords={
+            "lon": (("j", "i"), lons2d, {"standard_name": "longitude"}),
+            "lat": (("j", "i"), lats2d, {"standard_name": "latitude"}),
+        },
+    )
+
+    with pytest.raises(InvalidCoordinateValues, match="NaN/inf"):
+        Curvilinear.from_dataset(ds, CRS.from_epsg(4326), "lon", "lat")
 
 
 def test_detect_mesh_ugrid():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -19,9 +19,11 @@ from tests import NUMERIC_DTYPES
 from xpublish_tiles.config import config
 from xpublish_tiles.grids import guess_grid_system
 from xpublish_tiles.lib import (
+    InvalidCoordinateValues,
     _chunk_aligned_count,
     _chunk_sizes,
     adversarial_slicers,
+    anynotfinite,
     apply_default_pad,
     apply_range_colors,
     check_data_is_renderable_size,
@@ -32,7 +34,7 @@ from xpublish_tiles.lib import (
     transform_chunk,
     transform_coordinates,
 )
-from xpublish_tiles.pipeline import _parse_timedelta
+from xpublish_tiles.pipeline import _parse_timedelta, fix_coordinate_discontinuities
 from xpublish_tiles.projections import (
     epsg4326to3857,
     transformer_from_crs,
@@ -618,3 +620,56 @@ def test_min_zoom_covers_interior_tiles():
         assert num_over_limit(minzoom) == 0
         # and no higher than it has to be
         assert num_over_limit(minzoom - 1) > 0
+
+
+@pytest.mark.parametrize(
+    "array, expected",
+    [
+        (np.linspace(-180.0, 180.0, 32).reshape(4, 8), False),
+        (np.array([[1.0, np.nan], [3.0, 4.0]]), True),
+        (np.array([[1.0, np.inf], [3.0, 4.0]]), True),
+        (np.array([[1.0, -np.inf], [3.0, 4.0]]), True),
+        # Last element: the short-circuit must not stop early and miss it.
+        (np.array([[1.0, 2.0], [3.0, np.nan]]), True),
+        (np.array([], dtype=np.float64), False),
+        (np.zeros((3, 3), dtype=np.float32), False),
+        # Integers cannot hold NaN/inf — must not be rejected.
+        (np.arange(12).reshape(3, 4), False),
+    ],
+)
+def test_anynotfinite(array, expected):
+    assert anynotfinite(array) is expected
+
+
+@pytest.fixture
+def webmerc_transformer() -> pyproj.Transformer:
+    return pyproj.Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
+
+
+@pytest.mark.parametrize("axis", [None, 1])
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_fix_coordinate_discontinuities_rejects_nonfinite(webmerc_transformer, axis, bad):
+    """``axis=None`` hangs in ``unwrap_phase``; with an axis ``round(nan)`` raises.
+
+    Reached by HYCOM/RTOFS: fold-row lons past 360° map to ``inf`` in Web Mercator.
+    """
+    bbox = BBox(west=-180, south=-85, east=180, north=85)
+    poisoned = np.array([[0.0, 1.0e7], [2.0e7, bad]])
+
+    with pytest.raises(InvalidCoordinateValues, match="NaN/inf"):
+        fix_coordinate_discontinuities(
+            poisoned, webmerc_transformer, bbox=bbox, axis=axis
+        )
+
+
+@pytest.mark.parametrize("axis", [None, 1])
+def test_fix_coordinate_discontinuities_allows_finite(webmerc_transformer, axis):
+    """The guard must not reject ordinary all-finite coordinates."""
+    bbox = BBox(west=-180, south=-85, east=180, north=85)
+    coords = np.array([[0.0, 1.0e7], [2.0e7, -1.0e7]])
+
+    result = fix_coordinate_discontinuities(
+        coords, webmerc_transformer, bbox=bbox, axis=axis
+    )
+    assert np.isfinite(result).all()
+    assert result.shape == coords.shape

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,6 +24,7 @@ from xpublish_tiles import config
 from xpublish_tiles.lib import (
     AsyncLoadTimeoutError,
     IndexingError,
+    InvalidCoordinateValues,
     MissingParameterError,
     VariableNotFoundError,
     check_transparent_pixels,
@@ -49,6 +50,7 @@ from xpublish_tiles.testing.datasets import (
     REDGAUSS_N320,
     REGIONAL_HEALPIX_NA,
     TRIPOLE_ANTIMERIDIAN,
+    TRIPOLE_GLOBAL_UNWRAPPED,
     UGRID_TRIANGLES,
     _create_global_healpix,
     create_global_dataset,
@@ -1150,3 +1152,12 @@ async def test_pipeline_raster_style_not_supported():
     query_params = create_query_params(tile, tms, style="raster")
     with pytest.raises(ValueError, match="polygons"):
         await pipeline(ds, query_params)
+
+
+@pytest.mark.asyncio
+async def test_tripole_global_unwrapped_does_not_hang():
+    """RTOFS/HYCOM fold-row lons past 360° map to inf in Web Mercator; this used
+    to hang forever in ``unwrap_phase``."""
+    ds = TRIPOLE_GLOBAL_UNWRAPPED.create()
+    with pytest.raises(InvalidCoordinateValues):
+        await pipeline(ds, create_query_params(Tile(x=0, y=0, z=0), WEBMERC_TMS))


### PR DESCRIPTION
## Summary
- `fix_coordinate_discontinuities` and the curvilinear seam guard now raise `InvalidCoordinateValues` when coordinates hold NaN or ±inf. The 2D `unwrap_phase` never terminates on such input, and the seam guard only checked NaN, so inf slipped through.
- The tiles plugin maps `InvalidCoordinateValues` to a 422.
- Adds `tripole_global_unwrapped`, a synthetic RTOFS/HYCOM-style grid whose fold row carries whole-wrap lon offsets that Web Mercator maps to inf. It reproduces the hang end to end.

Rendering the fold-row tiles of such grids gap-free is not attempted here; they now fail fast instead of hanging.

## Test plan
- [x] `tests/test_lib.py`: `anynotfinite` and `fix_coordinate_discontinuities` reject NaN/±inf on both `axis` branches, accept finite input
- [x] `tests/test_grids.py`: seam-crossing curvilinear grid with NaN/±inf lons raises
- [x] `tests/test_pipeline.py`: `tripole_global_unwrapped` pipeline raises instead of hanging
- [x] `pre-commit run --all-files`, `uv run ty check src/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)